### PR TITLE
CDC reconnect repaired

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 #
 
 VERSION_MAJOR        := 1
-VERSION_MINOR        := 13
+VERSION_MINOR        := 14
 
 BUILD_DIR            := build
 PROJECT              := picoprobe
@@ -20,7 +20,7 @@ CMAKE_FLAGS += -DCMAKE_EXPORT_COMPILE_COMMANDS=True
 
 ifeq ($(PICO_BOARD),)
     # pico|pico_w|pico_debug_probe
-    PICO_BOARD := pico_debug_probe
+    PICO_BOARD := pico
 endif
 
 

--- a/README.adoc
+++ b/README.adoc
@@ -509,8 +509,17 @@ make create-images
 | https://documentation-service.arm.com/static/5f900b1af86e16515cdc0642[Debug Interface v5.2 Architecture Specification]
 | if the link does not work, try https://developer.arm.com/documentation/ihi0031/latest/[this]
 
+| https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst[Semihosting Information]
+|
+
 | https://github.com/raspberrypi/pico-sdk[Raspberry Pi Pico SDK]
 | 
+
+| https://github.com/pyocd/pyOCD[pyOCD on github]
+|
+
+| https://github.com/openocd-org/openocd[OpenOCD on github]
+| https://openocd.org/[Official Homepage]
 
 |===
 

--- a/README.adoc
+++ b/README.adoc
@@ -98,7 +98,7 @@ For details about probe pin assignments see the link:doc/hardware.adoc[hardware 
 
 |pyOCD 0.34.x
 |yes
-|no
+|yes
 |`pyocd flash -f 400000 -t nrf52840 firmware.elf`
 
 |cp / copy

--- a/doc/hardware.adoc
+++ b/doc/hardware.adoc
@@ -8,9 +8,32 @@
 
 ## Hardware
 
+### Existing Probe Hardware
+[%autowidth]
+[%header]
+|===
+| Name | Comment
+
+| https://www.raspberrypi.com/products/debug-probe/[Raspberry Pi Debug Probe]
+| the "original"
+
+| https://github.com/tjko/tiny-picoprobe[tiny-picoprobe]
+| small PCB to mount a regular Pico Pi board to work without breadboard
+
+| https://mcuoneclipse.com/2023/04/08/open-source-picolink-raspberry-pi-rp2040-cmsis-dap-debug-probe/[picoLink]
+| Open Source picoLink: Raspberry Pi RP2040 CMSIS-DAP Debug Probe
+
+|===
+
+All unfortunately without level shifters and without the possibility to use
+YaPicoprobes sigrok features.  So there is some space left for other hardware
+(ideas).
+
+
 ### Pin Assignments
 
 .Pins Assignments Rasberry Pi Pico
+[%autowidth]
 [%header]
 |===
 | Pin | Description
@@ -29,6 +52,7 @@
 |===
 
 .Other Pin Assigments Raspberry Pi Pico
+[%autowidth]
 [%header]
 |===
 | Pin | Description | Pico W

--- a/doc/hardware.adoc
+++ b/doc/hardware.adoc
@@ -17,11 +17,20 @@
 | https://www.raspberrypi.com/products/debug-probe/[Raspberry Pi Debug Probe]
 | the "original"
 
+| https://mcuoneclipse.com/2023/04/08/open-source-picolink-raspberry-pi-rp2040-cmsis-dap-debug-probe/[picoLink]
+| Open Source picoLink: Raspberry Pi RP2040 CMSIS-DAP Debug Probe
+
 | https://github.com/tjko/tiny-picoprobe[tiny-picoprobe]
 | small PCB to mount a regular Pico Pi board to work without breadboard
 
-| https://mcuoneclipse.com/2023/04/08/open-source-picolink-raspberry-pi-rp2040-cmsis-dap-debug-probe/[picoLink]
-| Open Source picoLink: Raspberry Pi RP2040 CMSIS-DAP Debug Probe
+| https://github.com/Fabien-Chouteau/picoprobe-pcb[Pimoroni Probe PCB]
+| converts a Pi Pico into a simple probe (with standard SWD connector)
+
+| https://github.com/ene9ba/PicoProbeHolder[Pico Probe Holder]
+| Adapter which also provides 3.3V and 5V to the target
+
+| https://github.com/martijnvwezel/pico-probe-programmer[Pico Probe Programmer]
+| Another PCB adapter
 
 |===
 

--- a/src/cdc_debug.c
+++ b/src/cdc_debug.c
@@ -99,6 +99,16 @@ void cdc_debug_thread(void *ptr)
                 }
             }
         }
+
+        if (tud_cdc_n_available(CDC_UART_N)) {
+            //
+            // eat receive characters (don't know if this has any effects, but who knows)
+            //
+            uint8_t ch;
+
+            tud_cdc_n_read(CDC_UART_N, &ch, sizeof(ch));
+        }
+
 #else
         xStreamBufferReceive(stream_printf, cdc_debug_buf, sizeof(cdc_debug_buf), pdMS_TO_TICKS(500));
 #endif
@@ -114,16 +124,10 @@ void cdc_debug_line_state_cb(bool dtr, bool rts)
  */
 {
 #if CFG_TUD_CDC_DEBUG
-    // CDC drivers use linestate as a bodge to activate/deactivate the interface.
-    if ( !dtr  &&  !rts) {
-        m_connected = false;
-        tud_cdc_n_write_clear(CDC_DEBUG_N);
-    }
-    else {
-        tud_cdc_n_write_clear(CDC_DEBUG_N);
-        m_connected = true;
-        xEventGroupSetBits(events, EV_TX_COMPLETE);
-    }
+    tud_cdc_n_write_clear(CDC_DEBUG_N);
+    tud_cdc_n_read_flush(CDC_DEBUG_N);
+    m_connected = (dtr  ||  rts);
+    xEventGroupSetBits(events, EV_TX_COMPLETE);
 #endif
 }   // cdc_debug_line_state_cb
 

--- a/src/cdc_uart.c
+++ b/src/cdc_uart.c
@@ -197,18 +197,10 @@ void cdc_uart_line_state_cb(bool dtr, bool rts)
  */
 {
 #if CFG_TUD_CDC_UART
-    // CDC drivers use linestate as a bodge to activate/deactivate the interface.
-    if ( !dtr  &&  !rts) {
-        m_connected = false;
-        tud_cdc_n_write_clear(CDC_UART_N);
-        tud_cdc_n_read_flush(CDC_UART_N);
-    }
-    else {
-        tud_cdc_n_write_clear(CDC_UART_N);
-        tud_cdc_n_read_flush(CDC_UART_N);
-        m_connected = true;
-        xEventGroupSetBits(events, EV_TX_COMPLETE);
-    }
+    tud_cdc_n_write_clear(CDC_UART_N);
+    tud_cdc_n_read_flush(CDC_UART_N);
+    m_connected = (dtr  ||  rts);
+    xEventGroupSetBits(events, EV_TX_COMPLETE);
 #endif
 }   // cdc_uart_line_state_cb
 

--- a/src/main.c
+++ b/src/main.c
@@ -124,6 +124,11 @@ void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts)
         cdc_debug_line_state_cb(dtr, rts);
     }
 #endif
+#if CFG_TUD_CDC_SIGROK
+    if (itf == CDC_SIGROK_N) {
+        cdc_sigrok_line_state_cb(dtr, rts);
+    }
+#endif
 }   // tud_cdc_line_state_cb
 
 

--- a/src/pico-sigrok/cdc_sigrok.c
+++ b/src/pico-sigrok/cdc_sigrok.c
@@ -72,18 +72,10 @@ void cdc_sigrok_line_state_cb(bool dtr, bool rts)
  */
 {
 #if CFG_TUD_CDC_SIGROK
-    // CDC drivers use linestate as a bodge to activate/deactivate the interface.
-    if ( !dtr  &&  !rts) {
-        m_connected = false;
-        tud_cdc_n_write_clear(CDC_SIGROK_N);
-        tud_cdc_n_read_flush(CDC_SIGROK_N);
-    }
-    else {
-        m_connected = true;
-        tud_cdc_n_write_clear(CDC_SIGROK_N);
-        tud_cdc_n_read_flush(CDC_SIGROK_N);
-        xEventGroupSetBits(events, EV_STREAM);
-    }
+    tud_cdc_n_write_clear(CDC_SIGROK_N);
+    tud_cdc_n_read_flush(CDC_SIGROK_N);
+    m_connected = (dtr  ||  rts);;
+    xEventGroupSetBits(events, EV_STREAM);
 #endif
 }   // cdc_uart_line_state_cb
 

--- a/src/pico-sigrok/cdc_sigrok.c
+++ b/src/pico-sigrok/cdc_sigrok.c
@@ -54,12 +54,38 @@ static TaskHandle_t           task_cdc_sigrok;
 static EventGroupHandle_t     events;
 static StreamBufferHandle_t   stream_sigrok;
 
+static volatile bool m_connected = false;
+
 
 
 void cdc_sigrok_tx_complete_cb(void)
 {
     xEventGroupSetBits(events, EV_TX);
 }   // cdc_sigrok_tx_complete_cb
+
+
+
+void cdc_sigrok_line_state_cb(bool dtr, bool rts)
+/**
+ * Flush tinyusb buffers on connect/disconnect.
+ * This seems to be necessary to survive e.g. a restart of the host (Linux)
+ */
+{
+#if CFG_TUD_CDC_SIGROK
+    // CDC drivers use linestate as a bodge to activate/deactivate the interface.
+    if ( !dtr  &&  !rts) {
+        m_connected = false;
+        tud_cdc_n_write_clear(CDC_SIGROK_N);
+        tud_cdc_n_read_flush(CDC_SIGROK_N);
+    }
+    else {
+        m_connected = true;
+        tud_cdc_n_write_clear(CDC_SIGROK_N);
+        tud_cdc_n_read_flush(CDC_SIGROK_N);
+        xEventGroupSetBits(events, EV_STREAM);
+    }
+#endif
+}   // cdc_uart_line_state_cb
 
 
 
@@ -304,19 +330,27 @@ void cdc_sigrok_thread()
         EventBits_t ev = EV_RX | EV_TX | EV_STREAM;
         size_t cdc_rx_chars;
 
+        if ( !m_connected) {
+            // wait here until connected (and until my terminal program is ready)
+            while ( !m_connected) {
+                xEventGroupWaitBits(events, EV_RX | EV_TX | EV_STREAM, pdTRUE, pdFALSE, pdMS_TO_TICKS(1000));
+            }
+            vTaskDelay(pdMS_TO_TICKS(100));
+        }
+
         cdc_rx_chars = tud_cdc_n_available(CDC_SIGROK_N);
         if (cdc_rx_chars == 0  &&  xStreamBufferIsEmpty(stream_sigrok)) {
             // -> nothing left to do: sleep for a long time
             tud_cdc_n_write_flush(CDC_SIGROK_N);
-            ev = xEventGroupWaitBits(events, EV_RX | EV_TX | EV_STREAM | EV_RX, pdTRUE, pdFALSE, pdMS_TO_TICKS(10000));
+            ev = xEventGroupWaitBits(events, EV_RX | EV_TX | EV_STREAM, pdTRUE, pdFALSE, pdMS_TO_TICKS(10000));
         }
         else if (cdc_rx_chars != 0) {
             // wait a short period if there are characters host -> probe -> target
-            ev = xEventGroupWaitBits(events, EV_RX | EV_TX | EV_STREAM | EV_RX, pdTRUE, pdFALSE, pdMS_TO_TICKS(1));
+            ev = xEventGroupWaitBits(events, EV_RX | EV_TX | EV_STREAM, pdTRUE, pdFALSE, pdMS_TO_TICKS(1));
         }
         else {
             // wait until transmission via USB has finished
-            ev = xEventGroupWaitBits(events, EV_RX | EV_TX | EV_STREAM | EV_RX, pdTRUE, pdFALSE, pdMS_TO_TICKS(100));
+            ev = xEventGroupWaitBits(events, EV_RX | EV_TX | EV_STREAM, pdTRUE, pdFALSE, pdMS_TO_TICKS(100));
         }
 
         if (ev & EV_RX) {

--- a/src/pico-sigrok/cdc_sigrok.h
+++ b/src/pico-sigrok/cdc_sigrok.h
@@ -39,6 +39,7 @@ void cdc_sigrok_init(uint32_t task_prio);
 void cdc_sigrok_write(const char *buf, int length);
 void cdc_sigrok_rx_cb(void);
 void cdc_sigrok_tx_complete_cb(void);
+void cdc_sigrok_line_state_cb(bool dtr, bool rts);
 
 void core1_code();
 


### PR DESCRIPTION
The CDCs did not survive a reboot of my Linux desktop and were blocked afterwards.

Seems that tud_cdc_n_write_clear() & tud_cdc_n_read_flush() are crucial for recovery.