### PR TITLE
Compile with Latest ARM GNU and Pico SDK

### DIFF
--- a/include/tusb_config.h
+++ b/include/tusb_config.h
@@ -153,7 +153,7 @@
 #if OPT_NET
     #define CFG_TUD_NET_MTU           1514
     
-    extern uint8_t tud_network_mac_address[6];
+    extern const uint8_t tud_network_mac_address[6];
 #endif
 
 #ifdef __cplusplus

--- a/src/get_config.c
+++ b/src/get_config.c
@@ -42,7 +42,7 @@ char usb_serial[PICO_UNIQUE_BOARD_ID_SIZE_BYTES * 2 + 1];
     /**
      * Network MAC address for global access: lwIP, TinyUSB
      */
-    uint8_t tud_network_mac_address[6];
+    const uint8_t tud_network_mac_address[6];
 #endif
 
 
@@ -56,10 +56,11 @@ void get_config_init(void)
     pico_get_unique_board_id(&uID);
 
 #if OPT_NET
-    tud_network_mac_address[0] = 0xfe;     // 0xfe is allowed for local use, never use odd numbers here (group/multicast)
+    uint8_t *tud_network_mac_address_local = (uint8_t *)tud_network_mac_address;
+    tud_network_mac_address_local[0] = 0xfe;     // 0xfe is allowed for local use, never use odd numbers here (group/multicast)
     for (int i = 1;  i < sizeof(tud_network_mac_address);  ++i)
     {
-        tud_network_mac_address[i] = uID.id[i + (PICO_UNIQUE_BOARD_ID_SIZE_BYTES - sizeof(tud_network_mac_address))];
+        tud_network_mac_address_local[i] = uID.id[i + (PICO_UNIQUE_BOARD_ID_SIZE_BYTES - sizeof(tud_network_mac_address))];
     }
 #endif
 

--- a/src/get_config.h
+++ b/src/get_config.h
@@ -130,7 +130,7 @@
 extern char usb_serial[];
 
 #if OPT_NET
-    extern uint8_t tud_network_mac_address[];
+    extern const uint8_t tud_network_mac_address[];
 #endif
 
 void get_config_init(void);

--- a/src/net/tinyusb/ncm.h
+++ b/src/net/tinyusb/ncm.h
@@ -30,6 +30,9 @@
 
 #include "common/tusb_common.h"
 
+#ifndef ECLIPSE_GUI
+    #define tu_static static
+#endif
 
 #ifndef CFG_TUD_NCM_IN_NTB_MAX_SIZE
     /// must be >> MTU

--- a/src/net/tinyusb/ncm_device.c
+++ b/src/net/tinyusb/ncm_device.c
@@ -33,7 +33,7 @@
 #if ECLIPSE_GUI || ( CFG_TUD_ENABLED && CFG_TUD_NCM )
 
 #if ECLIPSE_GUI
-    #define tu_static static
+    #define static static
 #endif
 
 #include <stdio.h>
@@ -81,7 +81,7 @@ typedef struct {
 // INTERNAL OBJECT & FUNCTION DECLARATION
 //--------------------------------------------------------------------+
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN tu_static const ntb_parameters_t ntb_parameters = {
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static const ntb_parameters_t ntb_parameters = {
         .wLength = sizeof(ntb_parameters_t),
         .bmNtbFormatsSupported = 0x01,                                 // 16-bit NTB supported
         .dwNtbInMaxSize = CFG_TUD_NCM_IN_NTB_MAX_SIZE,
@@ -96,9 +96,9 @@ CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN tu_static const ntb_parameters_t ntb_par
         .wNtbOutMaxDatagrams = 0                                       // 0=no limit TODO set to 0
 };
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN tu_static transmit_ntb_t transmit_ntb[2];
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static transmit_ntb_t transmit_ntb[2];
 
-tu_static ncm_interface_t ncm_interface;
+static ncm_interface_t ncm_interface;
 
 static void ncm_prepare_for_tx(void)
 /**
@@ -158,7 +158,7 @@ static void ncm_start_tx(void)
 
 
 
-tu_static struct ncm_notify_struct ncm_notify_connected = {
+static struct ncm_notify_struct ncm_notify_connected = {
         .header = {
                 .bmRequestType_bit = {
                         .recipient = TUSB_REQ_RCPT_INTERFACE,
@@ -171,7 +171,7 @@ tu_static struct ncm_notify_struct ncm_notify_connected = {
         },
 };
 
-tu_static struct ncm_notify_struct ncm_notify_speed_change = {
+static struct ncm_notify_struct ncm_notify_speed_change = {
         .header = {
                 .bmRequestType_bit = {
                         .recipient = TUSB_REQ_RCPT_INTERFACE,

--- a/src/net/tinyusb/ncm_device.c
+++ b/src/net/tinyusb/ncm_device.c
@@ -32,10 +32,6 @@
 
 #if ECLIPSE_GUI || ( CFG_TUD_ENABLED && CFG_TUD_NCM )
 
-#if ECLIPSE_GUI
-    #define tu_static static
-#endif
-
 #include <stdio.h>
 #include "device/usbd.h"
 #include "device/usbd_pvt.h"

--- a/src/net/tinyusb/ncm_device.c
+++ b/src/net/tinyusb/ncm_device.c
@@ -33,7 +33,7 @@
 #if ECLIPSE_GUI || ( CFG_TUD_ENABLED && CFG_TUD_NCM )
 
 #if ECLIPSE_GUI
-    #define static static
+    #define tu_static static
 #endif
 
 #include <stdio.h>
@@ -81,7 +81,7 @@ typedef struct {
 // INTERNAL OBJECT & FUNCTION DECLARATION
 //--------------------------------------------------------------------+
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static const ntb_parameters_t ntb_parameters = {
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN tu_static const ntb_parameters_t ntb_parameters = {
         .wLength = sizeof(ntb_parameters_t),
         .bmNtbFormatsSupported = 0x01,                                 // 16-bit NTB supported
         .dwNtbInMaxSize = CFG_TUD_NCM_IN_NTB_MAX_SIZE,
@@ -96,9 +96,9 @@ CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static const ntb_parameters_t ntb_parame
         .wNtbOutMaxDatagrams = 0                                       // 0=no limit TODO set to 0
 };
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static transmit_ntb_t transmit_ntb[2];
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN tu_static transmit_ntb_t transmit_ntb[2];
 
-static ncm_interface_t ncm_interface;
+tu_static ncm_interface_t ncm_interface;
 
 static void ncm_prepare_for_tx(void)
 /**
@@ -158,7 +158,7 @@ static void ncm_start_tx(void)
 
 
 
-static struct ncm_notify_struct ncm_notify_connected = {
+tu_static struct ncm_notify_struct ncm_notify_connected = {
         .header = {
                 .bmRequestType_bit = {
                         .recipient = TUSB_REQ_RCPT_INTERFACE,
@@ -171,7 +171,7 @@ static struct ncm_notify_struct ncm_notify_connected = {
         },
 };
 
-static struct ncm_notify_struct ncm_notify_speed_change = {
+tu_static struct ncm_notify_struct ncm_notify_speed_change = {
         .header = {
                 .bmRequestType_bit = {
                         .recipient = TUSB_REQ_RCPT_INTERFACE,

--- a/src/net/tinyusb/ncm_device_simple.c
+++ b/src/net/tinyusb/ncm_device_simple.c
@@ -32,7 +32,7 @@
 #if ECLIPSE_GUI || ( CFG_TUD_ENABLED && CFG_TUD_NCM )
 
 #if ECLIPSE_GUI
-    #define tu_static static
+    #define static static
 #endif
 
 #include <stdio.h>
@@ -81,7 +81,7 @@ typedef struct {
 // INTERNAL OBJECT & FUNCTION DECLARATION
 //--------------------------------------------------------------------+
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN tu_static const ntb_parameters_t ntb_parameters = {
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static const ntb_parameters_t ntb_parameters = {
         .wLength                 = sizeof(ntb_parameters_t),
         .bmNtbFormatsSupported   = 0x01,                                 // 16-bit NTB supported
         .dwNtbInMaxSize          = CFG_TUD_NCM_IN_NTB_MAX_SIZE,
@@ -96,9 +96,9 @@ CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN tu_static const ntb_parameters_t ntb_par
         .wNtbOutMaxDatagrams     = 1                                     // 0=no limit TODO set to 0
 };
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN tu_static transmit_ntb_t transmit_ntb;
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static transmit_ntb_t transmit_ntb;
 
-tu_static ncm_interface_t ncm_interface;
+static ncm_interface_t ncm_interface;
 
 
 
@@ -114,7 +114,7 @@ static void ncm_prepare_for_tx(void)
 
 
 
-tu_static struct ncm_notify_struct ncm_notify_connected = {
+static struct ncm_notify_struct ncm_notify_connected = {
         .header = {
                 .bmRequestType_bit = {
                         .recipient = TUSB_REQ_RCPT_INTERFACE,
@@ -127,7 +127,7 @@ tu_static struct ncm_notify_struct ncm_notify_connected = {
         },
 };
 
-tu_static struct ncm_notify_struct ncm_notify_speed_change = {
+static struct ncm_notify_struct ncm_notify_speed_change = {
         .header = {
                 .bmRequestType_bit = {
                         .recipient = TUSB_REQ_RCPT_INTERFACE,

--- a/src/net/tinyusb/ncm_device_simple.c
+++ b/src/net/tinyusb/ncm_device_simple.c
@@ -32,7 +32,7 @@
 #if ECLIPSE_GUI || ( CFG_TUD_ENABLED && CFG_TUD_NCM )
 
 #if ECLIPSE_GUI
-    #define static static
+    #define tu_static static
 #endif
 
 #include <stdio.h>
@@ -81,7 +81,7 @@ typedef struct {
 // INTERNAL OBJECT & FUNCTION DECLARATION
 //--------------------------------------------------------------------+
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static const ntb_parameters_t ntb_parameters = {
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN tu_static const ntb_parameters_t ntb_parameters = {
         .wLength                 = sizeof(ntb_parameters_t),
         .bmNtbFormatsSupported   = 0x01,                                 // 16-bit NTB supported
         .dwNtbInMaxSize          = CFG_TUD_NCM_IN_NTB_MAX_SIZE,
@@ -96,9 +96,9 @@ CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static const ntb_parameters_t ntb_parame
         .wNtbOutMaxDatagrams     = 1                                     // 0=no limit TODO set to 0
 };
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static transmit_ntb_t transmit_ntb;
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN tu_static transmit_ntb_t transmit_ntb;
 
-static ncm_interface_t ncm_interface;
+tu_static ncm_interface_t ncm_interface;
 
 
 
@@ -114,7 +114,7 @@ static void ncm_prepare_for_tx(void)
 
 
 
-static struct ncm_notify_struct ncm_notify_connected = {
+tu_static struct ncm_notify_struct ncm_notify_connected = {
         .header = {
                 .bmRequestType_bit = {
                         .recipient = TUSB_REQ_RCPT_INTERFACE,
@@ -127,7 +127,7 @@ static struct ncm_notify_struct ncm_notify_connected = {
         },
 };
 
-static struct ncm_notify_struct ncm_notify_speed_change = {
+tu_static struct ncm_notify_struct ncm_notify_speed_change = {
         .header = {
                 .bmRequestType_bit = {
                         .recipient = TUSB_REQ_RCPT_INTERFACE,

--- a/src/net/tinyusb/ncm_device_simple.c
+++ b/src/net/tinyusb/ncm_device_simple.c
@@ -31,10 +31,6 @@
 
 #if ECLIPSE_GUI || ( CFG_TUD_ENABLED && CFG_TUD_NCM )
 
-#if ECLIPSE_GUI
-    #define tu_static static
-#endif
-
 #include <stdio.h>
 #include "device/usbd.h"
 #include "device/usbd_pvt.h"

--- a/src/net/tinyusb/net_device.h
+++ b/src/net/tinyusb/net_device.h
@@ -78,7 +78,7 @@ void tud_network_init_cb(void);
 
 // client must provide this: 48-bit MAC address
 // TODO removed later since it is not part of tinyusb stack
-extern uint8_t tud_network_mac_address[6];
+extern const uint8_t tud_network_mac_address[6];
 
 //------------- NCM -------------//
 

--- a/src/net/tinyusb/net_device.h
+++ b/src/net/tinyusb/net_device.h
@@ -78,7 +78,7 @@ void tud_network_init_cb(void);
 
 // client must provide this: 48-bit MAC address
 // TODO removed later since it is not part of tinyusb stack
-extern const uint8_t tud_network_mac_address[6];
+extern uint8_t tud_network_mac_address[6];
 
 //------------- NCM -------------//
 


### PR DESCRIPTION
Fixes #60. Yapicoprobe now compiles and OpenOCD detects it, but it fails to initialize the DAP