### PR TITLE
Disabled GPIO slew rate config, which broke STM32 targets

### DIFF
--- a/src/probe.c
+++ b/src/probe.c
@@ -209,12 +209,14 @@ void probe_gpio_init()
 		pio_gpio_init(PROBE_PIO, PROBE_PIN_SWCLK);
 		pio_gpio_init(PROBE_PIO, PROBE_PIN_SWDIO);
 		// Make sure SWDIO has a pullup on it. Idle state is high
-#if 0
-		gpio_set_slew_rate(PROBE_PIN_SWCLK, GPIO_SLEW_RATE_FAST);
-		gpio_set_drive_strength(PROBE_PIN_SWCLK, GPIO_DRIVE_STRENGTH_12MA);
-#endif
 		gpio_pull_up(PROBE_PIN_SWDIO);
+
+    // Adjusting the GPIO slew and drive strength seems to break connectivity
+    // with certain targets, namely the STM32H7xx line of microcontrollers.
+    // For the time being, both parameters remain unset to ensure compatibility
 #if 0
+        gpio_set_slew_rate(PROBE_PIN_SWCLK, GPIO_SLEW_RATE_FAST);
+		gpio_set_drive_strength(PROBE_PIN_SWCLK, GPIO_DRIVE_STRENGTH_12MA);
         gpio_set_slew_rate(PROBE_PIN_SWDIO, GPIO_SLEW_RATE_FAST);
         gpio_set_drive_strength(PROBE_PIN_SWDIO, GPIO_DRIVE_STRENGTH_12MA);
 #endif

--- a/src/probe.c
+++ b/src/probe.c
@@ -209,11 +209,15 @@ void probe_gpio_init()
 		pio_gpio_init(PROBE_PIO, PROBE_PIN_SWCLK);
 		pio_gpio_init(PROBE_PIO, PROBE_PIN_SWDIO);
 		// Make sure SWDIO has a pullup on it. Idle state is high
+#if 0
 		gpio_set_slew_rate(PROBE_PIN_SWCLK, GPIO_SLEW_RATE_FAST);
 		gpio_set_drive_strength(PROBE_PIN_SWCLK, GPIO_DRIVE_STRENGTH_12MA);
+#endif
 		gpio_pull_up(PROBE_PIN_SWDIO);
+#if 0
         gpio_set_slew_rate(PROBE_PIN_SWDIO, GPIO_SLEW_RATE_FAST);
         gpio_set_drive_strength(PROBE_PIN_SWDIO, GPIO_DRIVE_STRENGTH_12MA);
+#endif
 
 		gpio_debug_pins_init();
 #ifdef PICOPROBE_LED_CONNECTED


### PR DESCRIPTION
This PR addresses #60 and #61. When interfacing with STM32 targets, setting the GPIO slew rate and drive strength seems to hinder yapicoprobe's ability to communicate. I have wrapped the offending configuration lines with `#if 0` directives in case they are required for platforms other than the Pico, which I am using.