### PR TITLE
Added carriage return to end of debug prints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ option(OPT_NET_ECHO_SERVER     "Enable echo server for testing"         1)
 option(OPT_NET_IPERF_SERVER    "Enable iperf server for tuning"         1)
 option(OPT_NET_SYSVIEW_SERVER  "Enable SysView over TCPIP"              1)
 option(OPT_CDC_SYSVIEW         "Enable SysView over CDC"                0)
+option(OPT_SERIAL_CRLF         "Insert carraige returns after debug print statements" 0)
 
 # extra
 option(OPT_SPECIAL_CLK_FOR_PIO "Ignore clock frequency request of 1MHz (this is for PlatformIO tuning)" 0)
@@ -323,6 +324,16 @@ if(OPT_MSC)
     if(OPT_MSC_RAM_UF2)
         add_compile_definitions(OPT_MSC_RAM_UF2=1)
     endif()
+endif()
+
+#--------------------------------------------------------------------------------------------------
+#
+# Some TTY clients (namely GNU screen) do not automatically insert a carriage return after a
+# newline. This configures the picoprobe's serial print functions to add the carriage return
+# explicitly at the end of each statement
+#
+if (OPT_SERIAL_CRLF)
+    add_compile_definitions(OPT_SERIAL_CRLF=1)
 endif()
 
 #--------------------------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ option(OPT_NET_ECHO_SERVER     "Enable echo server for testing"         1)
 option(OPT_NET_IPERF_SERVER    "Enable iperf server for tuning"         1)
 option(OPT_NET_SYSVIEW_SERVER  "Enable SysView over TCPIP"              1)
 option(OPT_CDC_SYSVIEW         "Enable SysView over CDC"                0)
-option(OPT_SERIAL_CRLF         "Insert carraige returns after debug print statements" 0)
+option(OPT_SERIAL_CRLF         "Insert carriage returns after debug print statements" 1)
 
 # extra
 option(OPT_SPECIAL_CLK_FOR_PIO "Ignore clock frequency request of 1MHz (this is for PlatformIO tuning)" 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ option(OPT_NET_ECHO_SERVER     "Enable echo server for testing"         1)
 option(OPT_NET_IPERF_SERVER    "Enable iperf server for tuning"         1)
 option(OPT_NET_SYSVIEW_SERVER  "Enable SysView over TCPIP"              1)
 option(OPT_CDC_SYSVIEW         "Enable SysView over CDC"                0)
-option(OPT_SERIAL_CRLF         "Insert carriage returns after debug print statements" 1)
+option(OPT_SERIAL_CRLF         "Insert carriage returns after debug print statements" 0)
 
 # extra
 option(OPT_SPECIAL_CLK_FOR_PIO "Ignore clock frequency request of 1MHz (this is for PlatformIO tuning)" 0)

--- a/include/picoprobe_config.h
+++ b/include/picoprobe_config.h
@@ -37,25 +37,25 @@
 #endif
 
 #if OPT_PROBE_DEBUG_OUT
-    #define picoprobe_info(format,args...) printf("(II) " format, ## args)
+    #define picoprobe_info(format,args...) printf("(II) \r" format, ## args)
 #else
     #define picoprobe_info(format,...) ((void)0)
 #endif
 
 #if 0  &&  OPT_PROBE_DEBUG_OUT
-    #define picoprobe_debug(format,args...) printf("(DD) " format, ## args)
+    #define picoprobe_debug(format,args...) printf("(DD) \r" format, ## args)
 #else
     #define picoprobe_debug(format,...) ((void)0)
 #endif
 
 #if 0  &&  OPT_PROBE_DEBUG_OUT
-    #define picoprobe_dump(format,args...) printf("(..) " format, ## args)
+    #define picoprobe_dump(format,args...) printf("(..) \r" format, ## args)
 #else
     #define picoprobe_dump(format,...) ((void)0)
 #endif
 
 #if 1  &&  OPT_PROBE_DEBUG_OUT
-    #define picoprobe_error(format,args...) printf("(EE) " format, ## args)
+    #define picoprobe_error(format,args...) printf("(EE) \r" format, ## args)
 #else
     #define picoprobe_error(format,...) ((void)0)
 #endif

--- a/include/picoprobe_config.h
+++ b/include/picoprobe_config.h
@@ -31,31 +31,31 @@
 
 
 #if OPT_PROBE_DEBUG_OUT
-    #define picoprobe_info_out(format,args...) printf(format, ## args)
+    #define picoprobe_info_out(format,args...) printf(format "\r", ## args)
 #else
     #define picoprobe_info_out(format,...) ((void)0)
 #endif
 
 #if OPT_PROBE_DEBUG_OUT
-    #define picoprobe_info(format,args...) printf("(II) \r" format, ## args)
+    #define picoprobe_info(format,args...) printf("(II) " format "\r", ## args)
 #else
     #define picoprobe_info(format,...) ((void)0)
 #endif
 
 #if 0  &&  OPT_PROBE_DEBUG_OUT
-    #define picoprobe_debug(format,args...) printf("(DD) \r" format, ## args)
+    #define picoprobe_debug(format,args...) printf("(DD) " format "\r", ## args)
 #else
     #define picoprobe_debug(format,...) ((void)0)
 #endif
 
 #if 0  &&  OPT_PROBE_DEBUG_OUT
-    #define picoprobe_dump(format,args...) printf("(..) \r" format, ## args)
+    #define picoprobe_dump(format,args...) printf("(..) " format "\r", ## args)
 #else
     #define picoprobe_dump(format,...) ((void)0)
 #endif
 
 #if 1  &&  OPT_PROBE_DEBUG_OUT
-    #define picoprobe_error(format,args...) printf("(EE) \r" format, ## args)
+    #define picoprobe_error(format,args...) printf("(EE) " format "\r", ## args)
 #else
     #define picoprobe_error(format,...) ((void)0)
 #endif

--- a/include/picoprobe_config.h
+++ b/include/picoprobe_config.h
@@ -29,7 +29,7 @@
 
 #define INCLUDE_RTT_CONSOLE
 
-#if OPT_SERIAL_CRLF
+#if defined(OPT_SERIAL_CRLF)
     #define CRLF "\r"
 #else
     #define CRLF ""

--- a/include/picoprobe_config.h
+++ b/include/picoprobe_config.h
@@ -29,33 +29,39 @@
 
 #define INCLUDE_RTT_CONSOLE
 
+#if OPT_SERIAL_CRLF
+    #define CRLF "\r"
+#else
+    #define CRLF ""
+#endif
+
 
 #if OPT_PROBE_DEBUG_OUT
-    #define picoprobe_info_out(format,args...) printf(format "\r", ## args)
+    #define picoprobe_info_out(format,args...) printf(format CRLF, ## args)
 #else
     #define picoprobe_info_out(format,...) ((void)0)
 #endif
 
 #if OPT_PROBE_DEBUG_OUT
-    #define picoprobe_info(format,args...) printf("(II) " format "\r", ## args)
+    #define picoprobe_info(format,args...) printf("(II) " format CRLF, ## args)
 #else
     #define picoprobe_info(format,...) ((void)0)
 #endif
 
 #if 0  &&  OPT_PROBE_DEBUG_OUT
-    #define picoprobe_debug(format,args...) printf("(DD) " format "\r", ## args)
+    #define picoprobe_debug(format,args...) printf("(DD) " format CRLF, ## args)
 #else
     #define picoprobe_debug(format,...) ((void)0)
 #endif
 
 #if 0  &&  OPT_PROBE_DEBUG_OUT
-    #define picoprobe_dump(format,args...) printf("(..) " format "\r", ## args)
+    #define picoprobe_dump(format,args...) printf("(..) " format CRLF, ## args)
 #else
     #define picoprobe_dump(format,...) ((void)0)
 #endif
 
 #if 1  &&  OPT_PROBE_DEBUG_OUT
-    #define picoprobe_error(format,args...) printf("(EE) " format "\r", ## args)
+    #define picoprobe_error(format,args...) printf("(EE) " format CRLF, ## args)
 #else
     #define picoprobe_error(format,...) ((void)0)
 #endif

--- a/include/picoprobe_config.h
+++ b/include/picoprobe_config.h
@@ -30,38 +30,38 @@
 #define INCLUDE_RTT_CONSOLE
 
 #if defined(OPT_SERIAL_CRLF)
-    #define PROBE_DEBUG_CRLF "\r"
+    #define PROBE_DEBUG_OPT_CR "\r"
 #else
-    #define PROBE_DEBUG_CRLF ""
+    #define PROBE_DEBUG_OPT_CR ""
 #endif
 
 
 #if OPT_PROBE_DEBUG_OUT
-    #define picoprobe_info_out(format,args...) printf(format PROBE_DEBUG_CRLF, ## args)
+    #define picoprobe_info_out(format,args...) printf(format PROBE_DEBUG_OPT_CR, ## args)
 #else
     #define picoprobe_info_out(format,...) ((void)0)
 #endif
 
 #if OPT_PROBE_DEBUG_OUT
-    #define picoprobe_info(format,args...) printf("(II) " format PROBE_DEBUG_CRLF, ## args)
+    #define picoprobe_info(format,args...) printf("(II) " format PROBE_DEBUG_OPT_CR, ## args)
 #else
     #define picoprobe_info(format,...) ((void)0)
 #endif
 
 #if 0  &&  OPT_PROBE_DEBUG_OUT
-    #define picoprobe_debug(format,args...) printf("(DD) " format PROBE_DEBUG_CRLF, ## args)
+    #define picoprobe_debug(format,args...) printf("(DD) " format PROBE_DEBUG_OPT_CR, ## args)
 #else
     #define picoprobe_debug(format,...) ((void)0)
 #endif
 
 #if 0  &&  OPT_PROBE_DEBUG_OUT
-    #define picoprobe_dump(format,args...) printf("(..) " format PROBE_DEBUG_CRLF, ## args)
+    #define picoprobe_dump(format,args...) printf("(..) " format PROBE_DEBUG_OPT_CR, ## args)
 #else
     #define picoprobe_dump(format,...) ((void)0)
 #endif
 
 #if 1  &&  OPT_PROBE_DEBUG_OUT
-    #define picoprobe_error(format,args...) printf("(EE) " format PROBE_DEBUG_CRLF, ## args)
+    #define picoprobe_error(format,args...) printf("(EE) " format PROBE_DEBUG_OPT_CR, ## args)
 #else
     #define picoprobe_error(format,...) ((void)0)
 #endif

--- a/include/picoprobe_config.h
+++ b/include/picoprobe_config.h
@@ -30,38 +30,38 @@
 #define INCLUDE_RTT_CONSOLE
 
 #if defined(OPT_SERIAL_CRLF)
-    #define CRLF "\r"
+    #define PROBE_DEBUG_CRLF "\r"
 #else
-    #define CRLF ""
+    #define PROBE_DEBUG_CRLF ""
 #endif
 
 
 #if OPT_PROBE_DEBUG_OUT
-    #define picoprobe_info_out(format,args...) printf(format CRLF, ## args)
+    #define picoprobe_info_out(format,args...) printf(format PROBE_DEBUG_CRLF, ## args)
 #else
     #define picoprobe_info_out(format,...) ((void)0)
 #endif
 
 #if OPT_PROBE_DEBUG_OUT
-    #define picoprobe_info(format,args...) printf("(II) " format CRLF, ## args)
+    #define picoprobe_info(format,args...) printf("(II) " format PROBE_DEBUG_CRLF, ## args)
 #else
     #define picoprobe_info(format,...) ((void)0)
 #endif
 
 #if 0  &&  OPT_PROBE_DEBUG_OUT
-    #define picoprobe_debug(format,args...) printf("(DD) " format CRLF, ## args)
+    #define picoprobe_debug(format,args...) printf("(DD) " format PROBE_DEBUG_CRLF, ## args)
 #else
     #define picoprobe_debug(format,...) ((void)0)
 #endif
 
 #if 0  &&  OPT_PROBE_DEBUG_OUT
-    #define picoprobe_dump(format,args...) printf("(..) " format CRLF, ## args)
+    #define picoprobe_dump(format,args...) printf("(..) " format PROBE_DEBUG_CRLF, ## args)
 #else
     #define picoprobe_dump(format,...) ((void)0)
 #endif
 
 #if 1  &&  OPT_PROBE_DEBUG_OUT
-    #define picoprobe_error(format,args...) printf("(EE) " format CRLF, ## args)
+    #define picoprobe_error(format,args...) printf("(EE) " format PROBE_DEBUG_CRLF, ## args)
 #else
     #define picoprobe_error(format,...) ((void)0)
 #endif


### PR DESCRIPTION
## Description
When using GNU screen, which does not automatically add carriage returns after new-lines, text wraps unnaturally across the console

For example:
```
  [CMSIS-DAPv1] [CMSIS-DAPv2] [MSC: DAPLink] [CDC: UART] [CDC: probe debug] [Net: 192.168.14.1 (NCM)] [Net: SysView] [Net: Echo] [Net: IPerf]
                                                             0.003 (  1) - (II) Probe HW:
         0.003 (  0) - (II)   Pico @ 240MHz
                                           0.003 (  0) - (II) ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
                                                                      0.003 (  0) - (II) SWD clk req   : 2000kHz = 240000kHz / (6 * (20 + 0/256)), eff : 2000kHz
                                                                                0.056 ( 53) - (II) Assign tasks to certain cores
                                                0.000 (  0) - (II) =================================== MSC connect target
                                         0.114 (114) - (II) =================================== MSC disconnect target
                                     0.298 (184) - (II) =================================== MSC connect target
                              0.412 (114) - (II) =================================== MSC disconnect target
                          1.576 (999) - (II) =================================== MSC connect target
                   1.689 (113) - (II) =================================== MSC disconnect target
```

This commit addresses the issue by explicitly adding carriage returns at the end of all calls to picoprobe_info() and similar functions. I am not sure if this is generally useful, but it certainly will benefit me, so I am sharing just in case.