### PR TITLE
probe-rs: RTT disable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # ATTENTION: to get the version number & git hash into the image, cmake-create-* has to be invoked.
 #
 VERSION_MAJOR        := 1
-VERSION_MINOR        := 19
+VERSION_MINOR        := 20
 
 BUILD_DIR            := _build
 PROJECT              := picoprobe

--- a/README.adoc
+++ b/README.adoc
@@ -350,6 +350,8 @@ Following procedure applies:
 ** `pwd` - set a password for locking the configuration.  Unlocking is done subsequently
    with `pwd:<your-pwd>`
 ** `r_start` / `r_end` - RAM start/end for generic target to override default 0x20000000..0x20040000.
+** `rtt` - enable/disable RTT access, default is RTT enabled (0: disable, 1:enable).  Note that `probe-rs` user must
+   currently set `rtt=0`
 * special characters:
 ** CR/LF - end the line
 ** BS - backspace one character

--- a/include/picoprobe_config.h
+++ b/include/picoprobe_config.h
@@ -100,8 +100,9 @@
 #define MININI_VAR_RSTART   "r_start"
 #define MININI_VAR_REND     "r_end"
 #define MININI_VAR_PWD      "pwd"
+#define MININI_VAR_RTT      "rtt"
 
 #define MININI_VAR_NAMES    MININI_VAR_NET, MININI_VAR_NICK, MININI_VAR_FCPU, MININI_VAR_FSWD, \
-                            MININI_VAR_RSTART, MININI_VAR_REND, MININI_VAR_PWD
+                            MININI_VAR_RSTART, MININI_VAR_REND, MININI_VAR_PWD, MININI_VAR_RTT
 
 #endif

--- a/src/cmsis-dap/dap_util.c
+++ b/src/cmsis-dap/dap_util.c
@@ -425,16 +425,20 @@ daptool_t DAP_FingerprintTool(const uint8_t *request, uint32_t request_len)
             }
         }
         else if (cnt == 3) {
-            if      (tool == E_DAPTOOL_PYOCD    &&  request[0] == ID_DAP_Info  &&  request[1] == DAP_ID_PACKET_SIZE) {
+            if      (tool == E_DAPTOOL_PYOCD    &&  request[0] == ID_DAP_Info  &&  request[1] == DAP_ID_PACKET_SIZE)
+            {
                 // ok (not sure if still used)
             }
-            else if (tool == E_DAPTOOL_PYOCD    &&  request[0] == ID_DAP_Info  &&  request[1] == DAP_ID_PRODUCT_FW_VER) {
+            else if (tool == E_DAPTOOL_PYOCD    &&  request[0] == ID_DAP_Info  &&  request[1] == DAP_ID_PRODUCT_FW_VER)
+            {
                 // ok (with DAP 2.1.2 & pyOCD 0.35)
             }
-            else if (tool == E_DAPTOOL_OPENOCD  &&  request[0] == ID_DAP_Info  &&  request[1] == DAP_ID_SER_NUM) {
+            else if (tool == E_DAPTOOL_OPENOCD  &&  request[0] == ID_DAP_Info  &&  request[1] == DAP_ID_SER_NUM)
+            {
                 // ok (with OpenOCD 0.11/0.12)
             }
-            else {
+            else
+            {
                 tool = E_DAPTOOL_UNKNOWN;
             }
         }

--- a/src/cmsis-dap/dap_util.c
+++ b/src/cmsis-dap/dap_util.c
@@ -417,9 +417,16 @@ daptool_t DAP_FingerprintTool(const uint8_t *request, uint32_t request_len)
             else if (request[0] == ID_DAP_Info  &&  request[1] == DAP_ID_CAPABILITIES) {
                 tool = E_DAPTOOL_OPENOCD;
             }
+            else if (request[0] == ID_DAP_Info  &&  request[1] == DAP_ID_PACKET_SIZE) {
+                tool = E_DAPTOOL_PROBERS;
+            }
         }
         else if (cnt == 2) {
-            if (request[0] != ID_DAP_Info  ||  request[1] != DAP_ID_DAP_FW_VER)
+            if (tool == E_DAPTOOL_PROBERS  &&  request[0] == ID_DAP_Info  &&  request[1] == DAP_ID_PACKET_COUNT)
+            {
+                // still E_DAPTOOL_PROBERS
+            }
+            else if (request[0] != ID_DAP_Info  ||  request[1] != DAP_ID_DAP_FW_VER)
             {
                 tool = E_DAPTOOL_UNKNOWN;
             }
@@ -436,6 +443,10 @@ daptool_t DAP_FingerprintTool(const uint8_t *request, uint32_t request_len)
             else if (tool == E_DAPTOOL_OPENOCD  &&  request[0] == ID_DAP_Info  &&  request[1] == DAP_ID_SER_NUM)
             {
                 // ok (with OpenOCD 0.11/0.12)
+            }
+            else if (tool == E_DAPTOOL_PROBERS  &&  request[0] == ID_DAP_Info  &&  request[1] == DAP_ID_CAPABILITIES)
+            {
+                // ok
             }
             else
             {

--- a/src/cmsis-dap/dap_util.h
+++ b/src/cmsis-dap/dap_util.h
@@ -32,7 +32,8 @@
 typedef enum {
     E_DAPTOOL_UNKNOWN,
     E_DAPTOOL_OPENOCD,
-    E_DAPTOOL_PYOCD
+    E_DAPTOOL_PYOCD,
+    E_DAPTOOL_PROBERS
 } daptool_t;
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -390,7 +390,10 @@ void usb_thread(void *ptr)
 #endif
 
 #if defined(INCLUDE_RTT_CONSOLE)
-    rtt_console_init(RTT_CONSOLE_TASK_PRIO);
+    if (ini_getbool(MININI_SECTION, MININI_VAR_RTT, true, MININI_FILENAME))
+    {
+        rtt_console_init(RTT_CONSOLE_TASK_PRIO);
+    }
 #endif
 
 #if OPT_SIGROK


### PR DESCRIPTION
probe-rs seems to have a very short timeout for CMSIS-DAPv2 so that sharing the DAP between debug probe and RTT does not work -> first aid is to disable RTT access