### PR TITLE
162: fix "probe-rs info"

### DIFF
--- a/src/cmsis-dap/dap_server.c
+++ b/src/cmsis-dap/dap_server.c
@@ -572,7 +572,7 @@ bool dap_is_connected(void)
 #if OPT_CMSIS_DAPV1
     r = r || hid_swd_connected;
 #endif
-#if OPT_CMSIS_DAPV1
+#if OPT_CMSIS_DAPV2
     r = r || swd_connected;
 #endif
 

--- a/src/cmsis-dap/dap_util.c
+++ b/src/cmsis-dap/dap_util.c
@@ -523,7 +523,6 @@ bool DAP_OfflineCommand(const uint8_t *request_data)
 {
     return      *request_data == ID_DAP_Info                // must be offline, "pyocd list" uses this
             ||  *request_data == ID_DAP_HostStatus          // must be offline, openocd/probe-rs uses this after disconnect
-//            ||  *request_data == ID_DAP_Connect           // not funny: with ID_DAP_Connect as offline cmd, probe-rs does not work reliably, not really clear why
-            ||  *request_data == ID_DAP_Disconnect          // this must be offline
+            ||  *request_data == ID_DAP_Disconnect          // this MUST be offline, otherwise openocd does not work
             ||  *request_data == ID_DAP_SWJ_Clock;          // this is not true, but unfortunately pyOCD does it
 }   // DAP_OfflineCommand

--- a/src/probe.c
+++ b/src/probe.c
@@ -357,6 +357,7 @@ void probe_init()
 
     if ( !probe.initted) {
 //        picoprobe_info("     2. probe_init()\n");
+
         uint offset = pio_add_program(PROBE_PIO, &probe_program);
         probe.offset = offset;
 
@@ -397,10 +398,21 @@ void probe_init()
 
 
 void probe_deinit(void)
+/**
+ * Stop the probe.
+ *
+ * \attention
+ *    This code should actually not be executed, because it might happen that ID_DAP_Disconnect is called while
+ *    not connected and then RTT functionality stumbles.
+ */
 {
+//    picoprobe_info("probe_deinit()\n");
+
+#if 0
     if (probe.initted) {
         pio_sm_set_enabled(PROBE_PIO, PROBE_PIO_SM, 0);
         pio_remove_program(PROBE_PIO, &probe_program, probe.offset);
         probe.initted = false;
     }
+#endif
 }   // prebe_deinit


### PR DESCRIPTION
probe_deinit() should do nothing otherwise RTT and probe_deinit() stumble upon each other