### PR TITLE
Hunting bugs and other features ;-)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ debuggEE-flash:
 debuggEE-flash-openocd:
 	$(MAKE) all-debuggEE
 	# openocd does much faster flashing
-	$(OPENOCD) -s $(OPENOCD_S) -f interface/cmsis-dap.cfg -f target/$(PICO_CHIPEE).cfg                                   \
+	$(OPENOCD) -s $(OPENOCD_S) -f interface/cmsis-dap.cfg -f target/$(PICO_CHIPEE).cfg                                 \
 	           -c "adapter speed 6000; adapter serial $(DEBUGGER_SERNO)"                                               \
 	           -c "program {$(BUILDEE_DIR)/$(PROJECT).hex}  verify; exit;"
 	# "pyocd reset" required to start
@@ -332,3 +332,8 @@ cmake-create-debugger: clean-build
 	         $(CMAKE_FLAGS)                                                                                            \
 	         -DPICO_CLIB=newlib                                                                                        \
 	         -DOPT_NET= -DOPT_SIGROK=0 -DOPT_MSC=0
+
+
+.PHONY: benchmark-probe-rs
+benchmark-probe-rs:
+	probe-rs benchmark --protocol swd --address 0x20020000 --min-speed 1000 --max-speed 10000 --chip $(PICO_CHIPEE)

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ endif
 #
 ifeq ($(PICO_BOARDEE),)
     # pico|pico_w|pico_debug_probe|pico2
-    PICO_BOARDEE := pico
+    PICO_BOARDEE := pico2
 endif
 
 PICO_CHIPEE := rp2040
@@ -244,7 +244,8 @@ all-debuggEE:
 .PHONY: debuggEE-flash
 debuggEE-flash:
 	$(MAKE) all-debuggEE
-	pyocd flash -f 6M --probe $(DEBUGGER_SERNO) -e auto $(BUILDEE_DIR)/$(PROJECT).hex
+	pyocd flash -t $(PICO_CHIPEE) -f 6M --probe $(DEBUGGER_SERNO) -e auto                          $(BUILDEE_DIR)/$(PROJECT).hex
+#	pyocd flash -t $(PICO_CHIPEE) -f 6M --probe $(DEBUGGER_SERNO) -e auto -L "pyocd.probe.*=debug" $(BUILDEE_DIR)/$(PROJECT).hex
 	@echo "ok."
 
 .PHONY: debuggEE-flash-openocd
@@ -255,7 +256,7 @@ debuggEE-flash-openocd:
 	           -c "adapter speed 6000; adapter serial $(DEBUGGER_SERNO)"                                               \
 	           -c "program {$(BUILDEE_DIR)/$(PROJECT).hex}  verify; exit;"
 	# "pyocd reset" required to start
-	pyocd reset -f 6M --probe $(DEBUGGER_SERNO)
+	pyocd reset -t $(PICO_CHIPEE) -f 6M --probe $(DEBUGGER_SERNO)
 	@echo "ok."
 
 .PHONY: debuggEE-flash-probe-rs
@@ -277,13 +278,13 @@ debuggEE-flash-erase:
 	#           -c "adapter speed 6000; adapter serial $(DEBUGGER_SERNO)"                                              \
 	#           -c "flash init; flash list; flash banks; init; flash erase_address 0x10000000 0x10000; init; exit;"
 	# and this one is slow because chip erase is not implemented in the blobs (src/daplink-pico/family/raspberry/flash_blob.c)
-	pyocd erase --mass
+	pyocd erase --mass -t $(PICO_CHIPEE) -f 6M --probe $(DEBUGGER_SERNO)
 	@echo "ok."
 
 
 .PHONY: debuggEE-reset
 debuggEE-reset:
-	pyocd reset -v -f 6M --probe $(DEBUGGER_SERNO)
+	pyocd reset -v -t $(PICO_CHIPEE) -f 6M --probe $(DEBUGGER_SERNO)
 
 .PHONY: debuggEE-reset-openocd
 debuggEE-reset-openocd:
@@ -302,7 +303,7 @@ cmake-create-debuggEE: clean-build-debuggEE
 	         $(CMAKE_FLAGS)                                                                                            \
  	         -DPICO_CLIB=$(DEBUGGEE_CLIB)                                                                              \
 	         -DOPT_NET= -DOPT_PROBE_DEBUG_OUT=RTT                                                                      \
-	         -DOPT_SIGROK=0 -DOPT_MSC=0 -DOPT_CMSIS_DAPV1=0 -DOPT_CMSIS_DAPV2=0 -DOPT_TARGET_UART=1
+	         -DOPT_SIGROK=0 -DOPT_MSC=0 -DOPT_CMSIS_DAPV1=0 -DOPT_CMSIS_DAPV2=1 -DOPT_TARGET_UART=1
 
 
 .PHONY: cmake-create-debuggEE-clang
@@ -313,7 +314,7 @@ cmake-create-debuggEE-clang: clean-build-debuggEE
  	         -DPICO_CLIB=llvm_libc                                                                                     \
 	         -DPICO_COMPILER=pico_arm_clang                                                                            \
 	         -DOPT_NET= -DOPT_PROBE_DEBUG_OUT=RTT                                                                      \
-	         -DOPT_SIGROK=0 -DOPT_MSC=0 -DOPT_CMSIS_DAPV1=0 -DOPT_CMSIS_DAPV2=0 -DOPT_TARGET_UART=1
+	         -DOPT_SIGROK=0 -DOPT_MSC=0 -DOPT_CMSIS_DAPV1=0 -DOPT_CMSIS_DAPV2=1 -DOPT_TARGET_UART=1
 
 
 .PHONY: cmake-create-debuggEE-release
@@ -322,7 +323,7 @@ cmake-create-debuggEE-release: clean-build-debuggEE
 	         $(CMAKE_FLAGS)                                                                                            \
 	         -DPICO_CLIB=$(DEBUGGEE_CLIB)                                                                              \
 	         -DOPT_NET= -DOPT_PROBE_DEBUG_OUT=RTT                                                                      \
-	         -DOPT_SIGROK=1 -DOPT_MSC=0 -DOPT_CMSIS_DAPV1=0 -DOPT_CMSIS_DAPV2=0 -DOPT_TARGET_UART=1
+	         -DOPT_SIGROK=1 -DOPT_MSC=0 -DOPT_CMSIS_DAPV1=0 -DOPT_CMSIS_DAPV2=1 -DOPT_TARGET_UART=1
 
 
 .PHONY: cmake-create-debugger

--- a/Makefile
+++ b/Makefile
@@ -260,9 +260,7 @@ debuggEE-flash-openocd:
 	# openocd does much faster flashing
 	$(OPENOCD) -s $(OPENOCD_S) -f interface/cmsis-dap.cfg -f target/$(PICO_CHIPEE).cfg                                 \
 	           -c "adapter speed 6000; adapter serial $(DEBUGGER_SERNO)"                                               \
-	           -c "program {$(BUILDEE_DIR)/$(PROJECT).hex}  verify; exit;"
-	# "pyocd reset" required to start
-	pyocd reset -t $(PICO_CHIPEE) -f 6M --probe $(DEBUGGER_SERNO)
+	           -c "program {$(BUILDEE_DIR)/$(PROJECT).hex}  verify reset exit"
 	@echo "ok."
 
 .PHONY: debuggEE-flash-probe-rs
@@ -296,7 +294,7 @@ debuggEE-reset:
 debuggEE-reset-openocd:
 	$(OPENOCD) -s $(OPENOCD_S) -f interface/cmsis-dap.cfg -f target/$(PICO_CHIPEE).cfg                                 \
 	           -c "adapter speed 6000; adapter serial $(DEBUGGER_SERNO)"                                               \
-	           -c "init; exit;"
+	           -c "init; reset run; exit;"
 
 .PHONY: debuggEE-reset-probe-rs
 debuggEE-reset-probe-rs:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 #
 VERSION_MAJOR        := 2
 VERSION_MINOR        := 2
-VERSION_PATCH        := 3
+VERSION_PATCH        := 4
 
 BUILD_DIR            := _build
 BUILDEE_DIR          := _buildee
@@ -221,7 +221,7 @@ show-options:
 # - most work is done in the debuggEE
 # 
 DEBUGGER_SERNO ?= 2739E00F30FE67E7
-OPENOCD_R := /home/hardy/.pico-sdk/openocd/0.12.0+dev
+OPENOCD_R := ~/.pico-sdk/openocd/0.12.0+dev
 OPENOCD   := $(OPENOCD_R)/openocd
 OPENOCD_S := $(OPENOCD_R)/scripts
 #DEBUGGEE_CLIB := picolibc
@@ -246,6 +246,12 @@ debuggEE-flash:
 	$(MAKE) all-debuggEE
 	pyocd flash -t $(PICO_CHIPEE) -f 6M --probe $(DEBUGGER_SERNO) -e auto                          $(BUILDEE_DIR)/$(PROJECT).hex
 #	pyocd flash -t $(PICO_CHIPEE) -f 6M --probe $(DEBUGGER_SERNO) -e auto -L "pyocd.probe.*=debug" $(BUILDEE_DIR)/$(PROJECT).hex
+	@echo "ok."
+
+.PHONY: debuggEE-flash-cp
+debuggEE-flash-cp:
+	$(MAKE) all-debuggEE
+	cp $(BUILDEE_DIR)/$(PROJECT).uf2 /media/picoprobe
 	@echo "ok."
 
 .PHONY: debuggEE-flash-openocd
@@ -337,3 +343,10 @@ cmake-create-debugger: clean-build
 .PHONY: benchmark-probe-rs
 benchmark-probe-rs:
 	probe-rs benchmark --protocol swd --address 0x20020000 --min-speed 1000 --max-speed 10000 --chip $(PICO_CHIPEE)
+
+
+# this is actually just a reminder for the probe-rs command line
+# "probe-rs gdb" does actually not run well under Eclipse(?)
+.PHONY: gdb-server-probe-rs
+gdb-server-probe-rs:
+	probe-rs gdb --chip rp2350 --gdb-connection-string 127.0.0.1:3333 --speed 9000 --protocol swd

--- a/README.adoc
+++ b/README.adoc
@@ -134,28 +134,14 @@ Those settings are:
 |===
 |Tool | Parameter
 
-|pyOCD / CMSIS-DAPv2
-|DAP_PACKET_COUNT=2 +
-DAP_PACKET_SIZE=512
-
-|OpenOCD / CMSIS-DAPv2
-|DAP_PACKET_COUNT=1 +
-DAP_PACKET_SIZE=1024
-
-|probe-rs / CMSIS-DAPv2
-|DAP_PACKET_COUNT=2 +
-DAP_PACKET_SIZE=1024
-
-|unknown / CMSIS-DAPv2
-|DAP_PACKET_COUNT=1 +
+|CMSIS-DAPv2
+|DAP_PACKET_COUNT=16 +
 DAP_PACKET_SIZE=64
 
 |CMSIS-DAPv1 HID
 |DAP_PACKET_COUNT=1 +
 DAP_PACKET_SIZE=64
 |===
-
-For the adventurous both parameters are also user settable, see <<runtime-configuration>>.
 
 
 #### SWD Adapter Speed
@@ -370,9 +356,6 @@ Following procedure applies:
   `ram_end` | RAM start/end for generic target to override default 0x20000000..0x20040000.  This is mainly for
               RTT detection
 | `rtt`     | enable/disable RTT access, default is RTT enabled (0: disable, 1:enable)
-| `dap_psize` +
-  `dap_pcnt`| set `DAP_PACKET_SIZE` and `DAP_PACKET_COUNT`, see <<dap-optimization>>.  If only one of those values
-              is set, the other goes to a default (64/1)
 |====
 * special characters:
 ** CR/LF - end the line

--- a/include/DAP_config.h
+++ b/include/DAP_config.h
@@ -97,7 +97,7 @@ This information includes:
 /// 1024 for High-speed USB HID and 512 for High-speed USB WinUSB.
 /// ATTENTION: terrible hack to make "dap_packet_size" a variable, see DAP_PACKET_COUNT
 extern uint16_t dap_packet_size;
-#define DAP_PACKET_SIZE     ((__LINE__ < 50) ? 64 : dap_packet_size)
+#define DAP_PACKET_SIZE     ((__LINE__ < 50) ? 512 : dap_packet_size)
 
 /// Maximum Package Buffers for Command and Response data.
 /// This configuration settings is used to optimize the communication performance with the
@@ -107,7 +107,7 @@ extern uint16_t dap_packet_size;
 ///            and CMSIS-DAPv1 works only with "1" (openocd)
 ///            The __LINE__ test is required to skip the test in DAP.c successfully.
 extern uint8_t dap_packet_count;
-#define DAP_PACKET_COUNT     ((__LINE__ < 50) ? 1 : dap_packet_count)
+#define DAP_PACKET_COUNT     ((__LINE__ < 50) ? 8 : dap_packet_count)
 
 /// Indicate that UART Serial Wire Output (SWO) trace is available.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.

--- a/include/DAP_config.h
+++ b/include/DAP_config.h
@@ -97,7 +97,7 @@ This information includes:
 /// 1024 for High-speed USB HID and 512 for High-speed USB WinUSB.
 /// ATTENTION: terrible hack to make "dap_packet_size" a variable, see DAP_PACKET_COUNT
 extern uint16_t dap_packet_size;
-#define DAP_PACKET_SIZE     ((__LINE__ < 50) ? 512 : dap_packet_size)
+#define DAP_PACKET_SIZE     ((__LINE__ < 50) ? 64 : dap_packet_size)
 
 /// Maximum Package Buffers for Command and Response data.
 /// This configuration settings is used to optimize the communication performance with the
@@ -107,7 +107,7 @@ extern uint16_t dap_packet_size;
 ///            and CMSIS-DAPv1 works only with "1" (openocd)
 ///            The __LINE__ test is required to skip the test in DAP.c successfully.
 extern uint8_t dap_packet_count;
-#define DAP_PACKET_COUNT     ((__LINE__ < 50) ? 8 : dap_packet_count)
+#define DAP_PACKET_COUNT     ((__LINE__ < 50) ? 16 : dap_packet_count)
 
 /// Indicate that UART Serial Wire Output (SWO) trace is available.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.

--- a/include/DAP_config.h
+++ b/include/DAP_config.h
@@ -97,7 +97,7 @@ This information includes:
 /// 1024 for High-speed USB HID and 512 for High-speed USB WinUSB.
 /// ATTENTION: terrible hack to make "dap_packet_size" a variable, see DAP_PACKET_COUNT
 extern uint16_t dap_packet_size;
-#define DAP_PACKET_SIZE     ((__LINE__ < 50) ? 512 : dap_packet_size)
+#define DAP_PACKET_SIZE     ((__LINE__ < 50) ? 64 : dap_packet_size)
 
 /// Maximum Package Buffers for Command and Response data.
 /// This configuration settings is used to optimize the communication performance with the
@@ -107,7 +107,7 @@ extern uint16_t dap_packet_size;
 ///            and CMSIS-DAPv1 works only with "1" (openocd)
 ///            The __LINE__ test is required to skip the test in DAP.c successfully.
 extern uint8_t dap_packet_count;
-#define DAP_PACKET_COUNT     ((__LINE__ < 50) ? 4 : dap_packet_count)
+#define DAP_PACKET_COUNT     ((__LINE__ < 50) ? 16 : dap_packet_count)
 
 /// Indicate that UART Serial Wire Output (SWO) trace is available.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.

--- a/include/DAP_config.h
+++ b/include/DAP_config.h
@@ -97,7 +97,7 @@ This information includes:
 /// 1024 for High-speed USB HID and 512 for High-speed USB WinUSB.
 /// ATTENTION: terrible hack to make "dap_packet_size" a variable, see DAP_PACKET_COUNT
 extern uint16_t dap_packet_size;
-#define DAP_PACKET_SIZE     ((__LINE__ < 50) ? 64 : dap_packet_size)
+#define DAP_PACKET_SIZE     ((__LINE__ < 50) ? 512 : dap_packet_size)
 
 /// Maximum Package Buffers for Command and Response data.
 /// This configuration settings is used to optimize the communication performance with the
@@ -107,7 +107,7 @@ extern uint16_t dap_packet_size;
 ///            and CMSIS-DAPv1 works only with "1" (openocd)
 ///            The __LINE__ test is required to skip the test in DAP.c successfully.
 extern uint8_t dap_packet_count;
-#define DAP_PACKET_COUNT     ((__LINE__ < 50) ? 16 : dap_packet_count)
+#define DAP_PACKET_COUNT     ((__LINE__ < 50) ? 4 : dap_packet_count)
 
 /// Indicate that UART Serial Wire Output (SWO) trace is available.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.

--- a/include/FreeRTOSConfig.h
+++ b/include/FreeRTOSConfig.h
@@ -97,7 +97,7 @@
 
     #warning "configGENERATE_RUN_TIME_STATS is set"
     #define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS()        do {} while( 0 )
-    //#define portALT_GET_RUN_TIME_COUNTER_VALUE( dest )      ( dest = *((uint32_t *)(TF_TIMER_BASE + TF_TIMER_TIMERAWL_OFFSET)) )
+    #define portALT_GET_RUN_TIME_COUNTER_VALUE( dest )      ( dest = xTickCount )
     #define portGET_RUN_TIME_COUNTER_VALUE()                (*((uint32_t *)(TF_TIMER_BASE + TF_TIMER_TIMERAWL_OFFSET)))
 
     #undef configUSE_TRACE_FACILITY
@@ -123,8 +123,12 @@
 
 #define configKERNEL_PROVIDED_STATIC_MEMORY     1
 
+/******************************************************************************************
+ * It seems that the probe runs better with a single core. No clue what the problem is.
+ ******************************************************************************************/
+
 /* SMP port only */
-#define configNUMBER_OF_CORES                   2
+#define configNUMBER_OF_CORES                   1
 #define configTICK_CORE                         1
 #define configRUN_MULTIPLE_PRIORITIES           1
 #if configNUMBER_OF_CORES != 1

--- a/include/FreeRTOSConfig.h
+++ b/include/FreeRTOSConfig.h
@@ -83,7 +83,7 @@
 #define configAPPLICATION_ALLOCATED_HEAP        0
 
 /* Hook function related definitions. */
-#define configCHECK_FOR_STACK_OVERFLOW          1
+#define configCHECK_FOR_STACK_OVERFLOW          2
 #define configUSE_MALLOC_FAILED_HOOK            1
 #define configUSE_DAEMON_TASK_STARTUP_HOOK      0
 
@@ -129,7 +129,7 @@
 
 /* SMP port only */
 #define configNUMBER_OF_CORES                   1
-#define configTICK_CORE                         1
+#define configTICK_CORE                         0
 #define configRUN_MULTIPLE_PRIORITIES           1
 #if configNUMBER_OF_CORES != 1
     #define configUSE_CORE_AFFINITY             1

--- a/include/picoprobe_config.h
+++ b/include/picoprobe_config.h
@@ -89,11 +89,8 @@
 #define MININI_VAR_REND      "ram_end"
 #define MININI_VAR_PWD       "pwd"
 #define MININI_VAR_RTT       "rtt"
-#define MININI_VAR_DAP_PSIZE "dap_psize"
-#define MININI_VAR_DAP_PCNT  "dap_pcnt"
 
 #define MININI_VAR_NAMES    MININI_VAR_NET, MININI_VAR_NICK, MININI_VAR_FCPU, MININI_VAR_FSWD, \
-                            MININI_VAR_RSTART, MININI_VAR_REND, MININI_VAR_PWD, MININI_VAR_RTT, \
-                            MININI_VAR_DAP_PSIZE, MININI_VAR_DAP_PCNT
+                            MININI_VAR_RSTART, MININI_VAR_REND, MININI_VAR_PWD, MININI_VAR_RTT
 
 #endif

--- a/src/cmsis-dap/dap_server.c
+++ b/src/cmsis-dap/dap_server.c
@@ -137,8 +137,8 @@
     // _DAP_PACKET_SIZE_NEW does not seem to be the decisive parameter, neither _DAP_PACKET_COUNT_NEW.
     // So below are good values
     //
-    #define _DAP_PACKET_COUNT_NEW       4
-    #define _DAP_PACKET_SIZE_NEW        512
+    #define _DAP_PACKET_COUNT_NEW       16
+    #define _DAP_PACKET_SIZE_NEW        64
 
 //    #define DAP_DEBUG                   1
 
@@ -915,7 +915,7 @@ bool dap_edpt_xfer_cb(uint8_t __unused rhport, uint8_t ep_addr, xfer_result_t re
             WR_SLOT_LEN(requestQueue) = xferred_bytes;
 
 #if _DAP_PACKET_SIZE_NEW != 64
-            if (xferred_bytes == DAP_GetCommandLength(RD_SLOT_PTR(requestQueue), xferred_bytes) + 1)
+            if (xferred_bytes == DAP_GetCommandLength(WR_SLOT_PTR(requestQueue), xferred_bytes) + 1)
             {
                 // this is a special pyocd (<= 0.42.0) hack (and of course openocd does not like it)
                 // see https://github.com/pyocd/pyOCD/issues/1871
@@ -1016,7 +1016,9 @@ void dap_thread(void *ptr)
             //
             if (RD_SLOT_LEN(requestQueue) != DAP_GetCommandLength(RD_SLOT_PTR(requestQueue), RD_SLOT_LEN(requestQueue)))
             {
-                picoprobe_error("dap_thread(): malformed request (probe may crash)\n");
+                picoprobe_error("dap_thread(): malformed request, len:%d, explen:%d (probe may crash)\n",
+                                (int)RD_SLOT_LEN(requestQueue),
+                                (int)DAP_GetCommandLength(RD_SLOT_PTR(requestQueue), RD_SLOT_LEN(requestQueue)));
             }
 #if 0  &&  DAP_DEBUG
             // better use DAPdeb.c

--- a/src/cmsis-dap/dap_server.c
+++ b/src/cmsis-dap/dap_server.c
@@ -136,7 +136,7 @@
     #define _DAP_PACKET_COUNT_NEW       16
     #define _DAP_PACKET_SIZE_NEW        64
 
-    #define DAP_DEBUG                   1
+//    #define DAP_DEBUG                   1
 
     #if (_DAP_PACKET_COUNT_NEW & (_DAP_PACKET_COUNT_NEW - 1)) != 0
         // no more restrictions here
@@ -981,7 +981,7 @@ void dap_thread(void *ptr)
             {
                 picoprobe_error("dap_thread(): malformed request (probe may crash)\n");
             }
-#if 1  &&  DAP_DEBUG
+#if 0  &&  DAP_DEBUG
             picoprobe_info("%u %u DAP cmd %s len %d %d\n",
                            (unsigned)requestQueue.wr_idx, (unsigned)requestQueue.rd_idx,
                            dap_cmd_string[RD_SLOT_PTR(requestQueue)[0]],

--- a/src/cmsis-dap/dap_server.c
+++ b/src/cmsis-dap/dap_server.c
@@ -764,7 +764,7 @@ static void HandleDapConnectDisconnect(const uint8_t *cmd, uint32_t cmdlen)
             sw_unlock(E_SWLOCK_DAPV2);
 
             // try to restart target after disconnect
-            target_set_state(HALT);
+            target_set_state(RESET_PROGRAM);
             target_set_state(RESET_RUN);
             rtt_console_redetect();
         }

--- a/src/cmsis-dap/dap_server.c
+++ b/src/cmsis-dap/dap_server.c
@@ -49,6 +49,7 @@
 #include "led.h"
 #include "sw_lock.h"
 #include "minIni/minIni.h"
+#include "rtt_io.h"
 
 /*
  * The following is part of a hack to make DAP_PACKET_COUNT a variable.
@@ -761,6 +762,11 @@ static void HandleDapConnectDisconnect(const uint8_t *cmd, uint32_t cmdlen)
             picoprobe_info("=================================== DAPv2 disconnect target\n");
             led_state(LS_DAPV2_DISCONNECTED);
             sw_unlock(E_SWLOCK_DAPV2);
+
+            // try to restart target after disconnect
+            target_set_state(HALT);
+            target_set_state(RESET_RUN);
+            rtt_console_redetect();
         }
     }
 }   // HandleDapConnectDisconnect

--- a/src/cmsis-dap/dap_server.c
+++ b/src/cmsis-dap/dap_server.c
@@ -124,7 +124,7 @@
     #define _DAP_PACKET_COUNT_NEW       16
     #define _DAP_PACKET_SIZE_NEW        64
 
-//    #define DAP_DEBUG                   1
+    #define DAP_DEBUG                   1
 
     #if (_DAP_PACKET_COUNT_NEW & (_DAP_PACKET_COUNT_NEW - 1)) != 0
         // no more restrictions here
@@ -215,6 +215,40 @@
     static SemaphoreHandle_t edpt_spoon;
 
     static bool swd_connected;
+
+#if DAP_DEBUG
+    static const char * dap_cmd_string[] = {
+        [ID_DAP_Info               ] = "DAP_Info",
+        [ID_DAP_HostStatus         ] = "DAP_HostStatus",
+        [ID_DAP_Connect            ] = "DAP_Connect",
+        [ID_DAP_Disconnect         ] = "DAP_Disconnect",
+        [ID_DAP_TransferConfigure  ] = "DAP_TransferConfigure",
+        [ID_DAP_Transfer           ] = "DAP_Transfer",
+        [ID_DAP_TransferBlock      ] = "DAP_TransferBlock",
+        [ID_DAP_TransferAbort      ] = "DAP_TransferAbort",
+        [ID_DAP_WriteABORT         ] = "DAP_WriteABORT",
+        [ID_DAP_Delay              ] = "DAP_Delay",
+        [ID_DAP_ResetTarget        ] = "DAP_ResetTarget",
+        [ID_DAP_SWJ_Pins           ] = "DAP_SWJ_Pins",
+        [ID_DAP_SWJ_Clock          ] = "DAP_SWJ_Clock",
+        [ID_DAP_SWJ_Sequence       ] = "DAP_SWJ_Sequence",
+        [ID_DAP_SWD_Configure      ] = "DAP_SWD_Configure",
+        [ID_DAP_SWD_Sequence       ] = "DAP_SWD_Sequence",
+        [ID_DAP_JTAG_Sequence      ] = "DAP_JTAG_Sequence",
+        [ID_DAP_JTAG_Configure     ] = "DAP_JTAG_Configure",
+        [ID_DAP_JTAG_IDCODE        ] = "DAP_JTAG_IDCODE",
+        [ID_DAP_SWO_Transport      ] = "DAP_SWO_Transport",
+        [ID_DAP_SWO_Mode           ] = "DAP_SWO_Mode",
+        [ID_DAP_SWO_Baudrate       ] = "DAP_SWO_Baudrate",
+        [ID_DAP_SWO_Control        ] = "DAP_SWO_Control",
+        [ID_DAP_SWO_Status         ] = "DAP_SWO_Status",
+        [ID_DAP_SWO_ExtendedStatus ] = "DAP_SWO_ExtendedStatus",
+        [ID_DAP_SWO_Data           ] = "DAP_SWO_Data",
+        [ID_DAP_QueueCommands      ] = "DAP_QueueCommands",
+        [ID_DAP_ExecuteCommands    ] = "DAP_ExecuteCommands",
+    };
+#endif
+
 #endif
 
 #if defined(NEW_DAP)  &&  OPT_CMSIS_DAPV1
@@ -668,41 +702,6 @@ bool dap_is_connected(void)
 
 
 #ifdef NEW_DAP
-
-#if DAP_DEBUG
-    static char * dap_cmd_string[] = {
-        [ID_DAP_Info               ] = "DAP_Info",
-        [ID_DAP_HostStatus         ] = "DAP_HostStatus",
-        [ID_DAP_Connect            ] = "DAP_Connect",
-        [ID_DAP_Disconnect         ] = "DAP_Disconnect",
-        [ID_DAP_TransferConfigure  ] = "DAP_TransferConfigure",
-        [ID_DAP_Transfer           ] = "DAP_Transfer",
-        [ID_DAP_TransferBlock      ] = "DAP_TransferBlock",
-        [ID_DAP_TransferAbort      ] = "DAP_TransferAbort",
-        [ID_DAP_WriteABORT         ] = "DAP_WriteABORT",
-        [ID_DAP_Delay              ] = "DAP_Delay",
-        [ID_DAP_ResetTarget        ] = "DAP_ResetTarget",
-        [ID_DAP_SWJ_Pins           ] = "DAP_SWJ_Pins",
-        [ID_DAP_SWJ_Clock          ] = "DAP_SWJ_Clock",
-        [ID_DAP_SWJ_Sequence       ] = "DAP_SWJ_Sequence",
-        [ID_DAP_SWD_Configure      ] = "DAP_SWD_Configure",
-        [ID_DAP_SWD_Sequence       ] = "DAP_SWD_Sequence",
-        [ID_DAP_JTAG_Sequence      ] = "DAP_JTAG_Sequence",
-        [ID_DAP_JTAG_Configure     ] = "DAP_JTAG_Configure",
-        [ID_DAP_JTAG_IDCODE        ] = "DAP_JTAG_IDCODE",
-        [ID_DAP_SWO_Transport      ] = "DAP_SWO_Transport",
-        [ID_DAP_SWO_Mode           ] = "DAP_SWO_Mode",
-        [ID_DAP_SWO_Baudrate       ] = "DAP_SWO_Baudrate",
-        [ID_DAP_SWO_Control        ] = "DAP_SWO_Control",
-        [ID_DAP_SWO_Status         ] = "DAP_SWO_Status",
-        [ID_DAP_SWO_ExtendedStatus ] = "DAP_SWO_ExtendedStatus",
-        [ID_DAP_SWO_Data           ] = "DAP_SWO_Data",
-        [ID_DAP_QueueCommands      ] = "DAP_QueueCommands",
-        [ID_DAP_ExecuteCommands    ] = "DAP_ExecuteCommands",
-    };
-#endif
-
-
 
 static void HandleDapConnectDisconnect(const uint8_t *cmd)
 /**

--- a/src/cmsis-dap/dap_server.c
+++ b/src/cmsis-dap/dap_server.c
@@ -37,6 +37,8 @@
 #include "timers.h"
 
 #include "tusb.h"
+#include "device/usbd.h"
+#include "device/usbd_pvt.h"
 
 #include "picoprobe_config.h"
 #include "dap_server.h"
@@ -97,14 +99,28 @@
  *       - does not use multi buffers for debugging
  *
  */
-#define _DAP_PACKET_COUNT_OPENOCD   1
-#define _DAP_PACKET_SIZE_OPENOCD    1024
-#define _DAP_PACKET_COUNT_PROBERS   2
-#define _DAP_PACKET_SIZE_PROBERS    1024
-#define _DAP_PACKET_COUNT_PYOCD     2
-#define _DAP_PACKET_SIZE_PYOCD      1024
-#define _DAP_PACKET_COUNT_UNKNOWN   1
-#define _DAP_PACKET_SIZE_UNKNOWN    64
+
+#define NEW_DAP
+
+#ifndef NEW_DAP
+    #define _DAP_PACKET_COUNT_OPENOCD   1
+    #define _DAP_PACKET_SIZE_OPENOCD    1024
+    #define _DAP_PACKET_COUNT_PROBERS   2
+    #define _DAP_PACKET_SIZE_PROBERS    1024
+    #define _DAP_PACKET_COUNT_PYOCD     2
+    #define _DAP_PACKET_SIZE_PYOCD      1024
+    #define _DAP_PACKET_COUNT_UNKNOWN   1
+    #define _DAP_PACKET_SIZE_UNKNOWN    64
+#else
+    #define _DAP_PACKET_COUNT_OPENOCD   8
+    #define _DAP_PACKET_SIZE_OPENOCD    512
+    #define _DAP_PACKET_COUNT_PROBERS   8
+    #define _DAP_PACKET_SIZE_PROBERS    512
+    #define _DAP_PACKET_COUNT_PYOCD     8
+    #define _DAP_PACKET_SIZE_PYOCD      512
+    #define _DAP_PACKET_COUNT_UNKNOWN   8
+    #define _DAP_PACKET_SIZE_UNKNOWN    512
+#endif
 
 #define _DAP_PACKET_COUNT_HID       1
 #define _DAP_PACKET_SIZE_HID        64
@@ -136,6 +152,38 @@ uint16_t dap_packet_size  = _DAP_PACKET_SIZE_UNKNOWN;
     static uint32_t rx_len = 0;
     static daptool_t dap_tool = E_DAPTOOL_UNKNOWN;
 #endif
+
+
+
+#define DAP_INTERFACE_SUBCLASS 0x00
+#define DAP_INTERFACE_PROTOCOL 0x00
+#define DAP_TASK_PRIO  (tskIDLE_PRIORITY + 1)
+
+#define WR_IDX(x) (x.wptr % _DAP_PACKET_COUNT_PYOCD)
+#define RD_IDX(x) (x.rptr % _DAP_PACKET_COUNT_PYOCD)
+
+#define WR_SLOT_PTR(x) (&(x.data[WR_IDX(x)][0]))
+#define RD_SLOT_PTR(x) (&(x.data[RD_IDX(x)][0]))
+
+typedef struct {
+    uint8_t data[_DAP_PACKET_COUNT_PYOCD][_DAP_PACKET_SIZE_PYOCD];
+    uint16_t data_len[_DAP_PACKET_COUNT_PYOCD];
+    volatile uint32_t wptr;
+    volatile uint32_t rptr;
+    volatile bool wasEmpty;
+    volatile bool wasFull;
+} buffer_t;
+
+static buffer_t USBRequestBuffer;
+static buffer_t USBResponseBuffer;
+
+static uint8_t itf_num;
+static uint8_t _rhport;
+
+static uint8_t _out_ep_addr;
+static uint8_t _in_ep_addr;
+
+static SemaphoreHandle_t edpt_spoon;
 
 
 
@@ -583,6 +631,298 @@ bool dap_is_connected(void)
 
 
 
+char * dap_cmd_string[] = {
+    [ID_DAP_Info               ] = "DAP_Info",
+    [ID_DAP_HostStatus         ] = "DAP_HostStatus",
+    [ID_DAP_Connect            ] = "DAP_Connect",
+    [ID_DAP_Disconnect         ] = "DAP_Disconnect",
+    [ID_DAP_TransferConfigure  ] = "DAP_TransferConfigure",
+    [ID_DAP_Transfer           ] = "DAP_Transfer",
+    [ID_DAP_TransferBlock      ] = "DAP_TransferBlock",
+    [ID_DAP_TransferAbort      ] = "DAP_TransferAbort",
+    [ID_DAP_WriteABORT         ] = "DAP_WriteABORT",
+    [ID_DAP_Delay              ] = "DAP_Delay",
+    [ID_DAP_ResetTarget        ] = "DAP_ResetTarget",
+    [ID_DAP_SWJ_Pins           ] = "DAP_SWJ_Pins",
+    [ID_DAP_SWJ_Clock          ] = "DAP_SWJ_Clock",
+    [ID_DAP_SWJ_Sequence       ] = "DAP_SWJ_Sequence",
+    [ID_DAP_SWD_Configure      ] = "DAP_SWD_Configure",
+    [ID_DAP_SWD_Sequence       ] = "DAP_SWD_Sequence",
+    [ID_DAP_JTAG_Sequence      ] = "DAP_JTAG_Sequence",
+    [ID_DAP_JTAG_Configure     ] = "DAP_JTAG_Configure",
+    [ID_DAP_JTAG_IDCODE        ] = "DAP_JTAG_IDCODE",
+    [ID_DAP_SWO_Transport      ] = "DAP_SWO_Transport",
+    [ID_DAP_SWO_Mode           ] = "DAP_SWO_Mode",
+    [ID_DAP_SWO_Baudrate       ] = "DAP_SWO_Baudrate",
+    [ID_DAP_SWO_Control        ] = "DAP_SWO_Control",
+    [ID_DAP_SWO_Status         ] = "DAP_SWO_Status",
+    [ID_DAP_SWO_ExtendedStatus ] = "DAP_SWO_ExtendedStatus",
+    [ID_DAP_SWO_Data           ] = "DAP_SWO_Data",
+    [ID_DAP_QueueCommands      ] = "DAP_QueueCommands",
+    [ID_DAP_ExecuteCommands    ] = "DAP_ExecuteCommands",
+};
+
+
+
+bool buffer_full(buffer_t *buffer)
+{
+    return ((buffer->wptr + 1) % _DAP_PACKET_COUNT_PYOCD == buffer->rptr);
+}   // buffer_full
+
+
+
+bool buffer_empty(buffer_t *buffer)
+{
+    return (buffer->wptr == buffer->rptr);
+}   // buffer_empty
+
+
+
+void dap_edpt_init(void)
+{
+    picoprobe_info("dap_edpt_init\n");
+    edpt_spoon = xSemaphoreCreateMutex();
+    xSemaphoreGive(edpt_spoon);
+}   // dap_edpt_init
+
+
+
+bool dap_edpt_deinit(void)
+{
+    picoprobe_info("dap_edpt_deinit\n");
+    memset(&USBRequestBuffer, 0, sizeof(USBRequestBuffer));
+    memset(&USBResponseBuffer, 0, sizeof(USBResponseBuffer));
+    vSemaphoreDelete(edpt_spoon);
+    return true;
+}   // dap_edpt_deinit
+
+
+
+void dap_edpt_reset(uint8_t __unused rhport)
+{
+    picoprobe_info("dap_edpt_reset\n");
+    itf_num = 0;
+}   // dap_edpt_reset
+
+
+
+uint16_t dap_edpt_open(uint8_t __unused rhport, tusb_desc_interface_t const *itf_desc, uint16_t max_len)
+{
+    picoprobe_info("dap_edpt_open\n");
+
+    TU_VERIFY(TUSB_CLASS_VENDOR_SPECIFIC == itf_desc->bInterfaceClass &&
+              DAP_INTERFACE_SUBCLASS == itf_desc->bInterfaceSubClass &&
+              DAP_INTERFACE_PROTOCOL == itf_desc->bInterfaceProtocol, 0);
+
+    //  Initialise circular buffer indices
+    USBResponseBuffer.wptr = 0;
+    USBResponseBuffer.rptr = 0;
+    USBRequestBuffer.wptr = 0;
+    USBRequestBuffer.rptr = 0;
+
+    // Initialse full/empty flags
+    USBResponseBuffer.wasFull = false;
+    USBResponseBuffer.wasEmpty = true;
+    USBRequestBuffer.wasFull = false;
+    USBRequestBuffer.wasEmpty = true;
+
+    uint16_t const drv_len = sizeof(tusb_desc_interface_t) + (itf_desc->bNumEndpoints * sizeof(tusb_desc_endpoint_t));
+    TU_VERIFY(max_len >= drv_len, 0);
+    itf_num = itf_desc->bInterfaceNumber;
+
+    // Initialising the OUT endpoint
+
+    tusb_desc_endpoint_t *edpt_desc = (tusb_desc_endpoint_t *) (itf_desc + 1);
+    uint8_t ep_addr = edpt_desc->bEndpointAddress;
+
+    _out_ep_addr = ep_addr;
+
+    // The OUT endpoint requires a call to usbd_edpt_xfer to initialise the endpoint, giving tinyUSB a buffer to consume when a transfer occurs at the endpoint
+    usbd_edpt_open(rhport, edpt_desc);
+    usbd_edpt_xfer(rhport, ep_addr, WR_SLOT_PTR(USBRequestBuffer), _DAP_PACKET_SIZE_PYOCD, false);
+
+    // Initiliasing the IN endpoint
+
+    edpt_desc++;
+    ep_addr = edpt_desc->bEndpointAddress;
+
+    _in_ep_addr = ep_addr;
+
+    // The IN endpoint doesn't need a transfer to initialise it, as this will be done by the main loop of dap_thread
+    usbd_edpt_open(rhport, edpt_desc);
+
+    // Spawn DAP thread?
+
+    return drv_len;
+}   // dap_edpt_open
+
+
+
+bool dap_edpt_control_xfer_cb(uint8_t __unused rhport, uint8_t stage, tusb_control_request_t const *request)
+{
+    picoprobe_info("dap_edpt_control_xfer_cb\n");
+    return false;
+}   // dap_edpt_control_xfer_cb
+
+
+
+bool dap_edpt_xfer_cb(uint8_t __unused rhport, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes)
+{
+//    picoprobe_info("dap_edpt_xfer_cb\n");
+    const uint8_t ep_dir = tu_edpt_dir(ep_addr);
+
+    if(ep_dir == TUSB_DIR_IN)
+    {
+        if(xferred_bytes >= 0u && xferred_bytes <= _DAP_PACKET_SIZE_PYOCD)
+        {
+            xSemaphoreTake(edpt_spoon, portMAX_DELAY);
+            USBResponseBuffer.rptr++;
+            // This checks that the buffer was not empty in DAP thread, which means the next buffer was not queued up for the in endpoint callback
+            // So, queue up the buffer at the new read index, since we expect read to catch up to write at this point.
+            // It is possible for the read index to be multiple spaces behind the write index (if the USB callbacks are lagging behind dap thread),
+            // so we account for this by only setting wasEmpty to true if the next callback will empty the buffer
+            if( !USBResponseBuffer.wasEmpty)
+            {
+                usbd_edpt_xfer(rhport, ep_addr, RD_SLOT_PTR(USBResponseBuffer), USBResponseBuffer.data_len[RD_IDX(USBResponseBuffer)], false);
+                USBResponseBuffer.wasEmpty = (USBResponseBuffer.rptr + 1) == USBResponseBuffer.wptr;
+            }
+            xSemaphoreGive(edpt_spoon);
+            //  Wake up DAP thread after processing the callback
+            xTaskNotify(dap_taskhandle, 0, eSetValueWithOverwrite);
+            return true;
+        }
+        return false;
+
+    } else if(ep_dir == TUSB_DIR_OUT) {
+
+        if(xferred_bytes >= 0u && xferred_bytes <= _DAP_PACKET_SIZE_PYOCD)
+        {
+            xSemaphoreTake(edpt_spoon, portMAX_DELAY);
+            // Only queue the next buffer in the out callback if the buffer is not full
+            // If full, we set the wasFull flag, which will be checked by dap thread
+            if( !buffer_full(&USBRequestBuffer))
+            {
+                USBRequestBuffer.wptr++;
+                usbd_edpt_xfer(rhport, ep_addr, WR_SLOT_PTR(USBRequestBuffer), _DAP_PACKET_SIZE_PYOCD, false);
+                USBRequestBuffer.wasFull = false;
+            }
+            else {
+                USBRequestBuffer.wasFull = true;
+            }
+            xSemaphoreGive(edpt_spoon);
+            //  Wake up DAP thread after processing the callback
+            xTaskNotify(dap_taskhandle, 0, eSetValueWithOverwrite);
+            return true;
+        }
+        return false;
+    }
+    return false;
+}   // dap_edpt_xfer_cb
+
+
+
+void dap_thread(void *ptr)
+{
+    uint32_t n;
+    uint32_t cmd;
+    uint16_t resp_len;
+    do
+    {
+        // Wait for usb CB wake
+        xTaskNotifyWait(0, 0xFFFFFFFFu, &cmd, 1);
+        while(USBRequestBuffer.rptr != USBRequestBuffer.wptr)
+        {
+            /*
+             * Atomic command support - buffer QueueCommands, but don't process them
+             * until a non-QueueCommands packet is seen.
+             */
+            n = USBRequestBuffer.rptr;
+            while (USBRequestBuffer.data[n % _DAP_PACKET_COUNT_PYOCD][0] == ID_DAP_QueueCommands) {
+                picoprobe_info("%u %u DAP queued cmd %s len %d\n",
+                               USBRequestBuffer.wptr, USBRequestBuffer.rptr,
+                               dap_cmd_string[USBRequestBuffer.data[n % _DAP_PACKET_COUNT_PYOCD][0]], USBRequestBuffer.data[n % _DAP_PACKET_COUNT_PYOCD][1]);
+                USBRequestBuffer.data[n % _DAP_PACKET_COUNT_PYOCD][0] = ID_DAP_ExecuteCommands;
+                n++;
+                while (n == USBRequestBuffer.wptr) {
+                    /* Need yield in a loop here, as IN callbacks will also wake the thread */
+                    picoprobe_info("DAP wait\n");
+                    vTaskSuspend(dap_taskhandle);
+                }
+            }
+            // Read a single packet from the USB buffer into the DAP Request buffer
+            picoprobe_info("%u %u DAP cmd %s len %d\n",
+                           USBRequestBuffer.wptr, USBRequestBuffer.rptr,
+                           dap_cmd_string[RD_SLOT_PTR(USBRequestBuffer)[0]], RD_SLOT_PTR(USBRequestBuffer)[1]);
+
+            // If the buffer was full in the out callback, we need to queue up another buffer for the endpoint to consume, now that we know there is space in the buffer.
+            xSemaphoreTake(edpt_spoon, portMAX_DELAY); // Suspend the scheduler to safely update the write index
+            if(USBRequestBuffer.wasFull)
+            {
+                USBRequestBuffer.wptr++;
+                usbd_edpt_xfer(_rhport, _out_ep_addr, WR_SLOT_PTR(USBRequestBuffer), _DAP_PACKET_SIZE_PYOCD, false);
+                USBRequestBuffer.wasFull = false;
+            }
+            xSemaphoreGive(edpt_spoon);
+
+            resp_len = DAP_ExecuteCommand(RD_SLOT_PTR(USBRequestBuffer), WR_SLOT_PTR(USBResponseBuffer)) & 0xffff;
+            USBRequestBuffer.rptr++;
+            picoprobe_info("%u %u DAP resp %s len %d\n",
+                           USBResponseBuffer.wptr, USBResponseBuffer.rptr,
+                           dap_cmd_string[WR_SLOT_PTR(USBResponseBuffer)[0]], resp_len);
+
+            USBResponseBuffer.data_len[WR_IDX(USBResponseBuffer)] = resp_len;
+            //  Suspend the scheduler to avoid stale values/race conditions between threads
+            xSemaphoreTake(edpt_spoon, portMAX_DELAY);
+
+            if(buffer_empty(&USBResponseBuffer))
+            {
+                USBResponseBuffer.wptr++;
+
+                usbd_edpt_xfer(_rhport, _in_ep_addr, RD_SLOT_PTR(USBResponseBuffer), USBResponseBuffer.data_len[RD_IDX(USBResponseBuffer)], false);
+            } else {
+
+                USBResponseBuffer.wptr++;
+
+                // The In callback needs to check this flag to know when to queue up the next buffer.
+                USBResponseBuffer.wasEmpty = false;
+            }
+            xSemaphoreGive(edpt_spoon);
+        }
+    } while (1);
+}   // dap_thread
+
+
+
+usbd_class_driver_t const _dap_edpt_driver =
+{
+        .init            = dap_edpt_init,
+        .deinit          = dap_edpt_deinit,
+        .reset           = dap_edpt_reset,
+        .open            = dap_edpt_open,
+        .control_xfer_cb = dap_edpt_control_xfer_cb,
+        .xfer_cb         = dap_edpt_xfer_cb,
+        .xfer_isr        = NULL,
+        .sof             = NULL,
+#if CFG_TUSB_DEBUG >= 2
+        .name            = "DAP ENDPOINT"
+#endif
+};
+
+
+
+#ifdef NEW_DAP
+usbd_class_driver_t const *usbd_app_driver_get_cb(uint8_t *driver_count)
+/**
+ *  Add the custom driver to the tinyUSB stack
+ */
+{
+    *driver_count = 1;
+    return &_dap_edpt_driver;
+}   // usbd_app_driver_get_cb
+#endif
+
+
+
 #if OPT_CMSIS_DAPV2
 static void dap_reset_tool_timeout(TimerHandle_t xTimer)
 {
@@ -599,6 +939,9 @@ static void dap_reset_tool_timeout(TimerHandle_t xTimer)
 void dap_server_init(uint32_t task_prio)
 {
     picoprobe_debug("dap_server_init(%u)\n", (unsigned)task_prio);
+
+    /* Lowest priority thread is debug - need to shuffle buffers before we can toggle swd... */
+    xTaskCreate(dap_thread, "DAP", configMINIMAL_STACK_SIZE, NULL, DAP_TASK_PRIO, &dap_taskhandle);
 
 #if OPT_CMSIS_DAPV2
     dap_stream = xStreamBufferCreate(BUFFER_MAXSIZE, 1);

--- a/src/cmsis-dap/dap_server.c
+++ b/src/cmsis-dap/dap_server.c
@@ -95,7 +95,8 @@
  *       - does no disconnect on end of debug sessions (small piece of code is missing, see
  *         https://github.com/pyocd/pyOCD/issues/1531 and
  *         https://github.com/pyocd/pyOCD/pull/1869 (still open)
- *       - this means that the tool detection does not work in this case
+ *       - this means that the tool detection does not work in this case.  After introducing a timeout in
+ *         finger printing, only the connect message is missing
  *       - BUT does not access the SW if debugging is halted and seems to restore DP state
  *       - "pyocd list" does only DAP_Info, no connect/disconnect -> not simple to recover from this tool detection
  *     - openocd

--- a/src/cmsis-dap/dap_server.c
+++ b/src/cmsis-dap/dap_server.c
@@ -858,11 +858,13 @@ bool dap_edpt_control_xfer_cb(uint8_t __unused rhport, uint8_t stage, tusb_contr
 
 
 
+#if TUSB_VERSION_NUMBER > 2000  // 0.20.0
 bool dap_edpt_xfer_isr_cb(uint8_t __unused rhport, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes)
 {
 //    picoprobe_info("dap_edpt_xfer_isr_cb !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
     return false;
 }   // dap_edpt_xfer_isr_cb
+#endif
 
 
 
@@ -1097,7 +1099,9 @@ usbd_class_driver_t const _dap_edpt_driver =
         .open            = dap_edpt_open,
         .control_xfer_cb = dap_edpt_control_xfer_cb,
         .xfer_cb         = dap_edpt_xfer_cb,
+#if TUSB_VERSION_NUMBER > 2000  // 0.20.0
         .xfer_isr        = dap_edpt_xfer_isr_cb,
+#endif
         .sof             = NULL,
 #if CFG_TUSB_DEBUG >= 2
         .name            = "DAP ENDPOINT"

--- a/src/cmsis-dap/dap_server.c
+++ b/src/cmsis-dap/dap_server.c
@@ -763,9 +763,6 @@ static void HandleDapConnectDisconnect(const uint8_t *cmd, uint32_t cmdlen)
             led_state(LS_DAPV2_DISCONNECTED);
             sw_unlock(E_SWLOCK_DAPV2);
 
-            // try to restart target after disconnect
-            target_set_state(RESET_PROGRAM);
-            target_set_state(RESET_RUN);
             rtt_console_redetect();
         }
     }

--- a/src/cmsis-dap/dap_server.c
+++ b/src/cmsis-dap/dap_server.c
@@ -762,8 +762,6 @@ static void HandleDapConnectDisconnect(const uint8_t *cmd, uint32_t cmdlen)
             picoprobe_info("=================================== DAPv2 disconnect target\n");
             led_state(LS_DAPV2_DISCONNECTED);
             sw_unlock(E_SWLOCK_DAPV2);
-
-            rtt_console_redetect();
         }
     }
 }   // HandleDapConnectDisconnect

--- a/src/cmsis-dap/dap_server.c
+++ b/src/cmsis-dap/dap_server.c
@@ -137,8 +137,8 @@
     // _DAP_PACKET_SIZE_NEW does not seem to be the decisive parameter, neither _DAP_PACKET_COUNT_NEW.
     // So below are good values
     //
-    #define _DAP_PACKET_COUNT_NEW       16
-    #define _DAP_PACKET_SIZE_NEW        64
+    #define _DAP_PACKET_COUNT_NEW       4
+    #define _DAP_PACKET_SIZE_NEW        512
 
 //    #define DAP_DEBUG                   1
 
@@ -1019,6 +1019,7 @@ void dap_thread(void *ptr)
                 picoprobe_error("dap_thread(): malformed request (probe may crash)\n");
             }
 #if 0  &&  DAP_DEBUG
+            // better use DAPdeb.c
             picoprobe_info("%u %u DAP cmd %s len %d %d\n",
                            (unsigned)requestQueue.wr_idx, (unsigned)requestQueue.rd_idx,
                            dap_cmd_string[RD_SLOT_PTR(requestQueue)[0]],

--- a/src/cmsis-dap/dap_util.c
+++ b/src/cmsis-dap/dap_util.c
@@ -524,5 +524,6 @@ bool DAP_OfflineCommand(const uint8_t *request_data)
     return      *request_data == ID_DAP_Info                // must be offline, "pyocd list" uses this
             ||  *request_data == ID_DAP_HostStatus          // must be offline, openocd/probe-rs uses this after disconnect
             ||  *request_data == ID_DAP_Disconnect          // this MUST be offline, otherwise openocd does not work
-            ||  *request_data == ID_DAP_SWJ_Clock;          // this is not true, but unfortunately pyOCD does it
+//            ||  *request_data == ID_DAP_SWJ_Clock           // this is not true, but unfortunately pyOCD does it
+            ;
 }   // DAP_OfflineCommand

--- a/src/cmsis-dap/dap_util.c
+++ b/src/cmsis-dap/dap_util.c
@@ -413,11 +413,13 @@ daptool_t DAP_FingerprintTool(const uint8_t *request, uint32_t request_len)
     static uint32_t sample_no;
     static daptool_t probed_tool;
 
-    if (request == NULL  ||  request_len == 0) {
+    if (request == NULL  ||  request_len == 0  ||  request[0] == ID_DAP_Disconnect) {
         sample_no = 0;
         probed_tool = E_DAPTOOL_UNKNOWN;
         return probed_tool;
     }
+    // post: request != NULL  &&  request_len != 0  &&  request[0] != ID_DAP_Disconnect
+
     if (request[0] != ID_DAP_Info  ||  probed_tool != E_DAPTOOL_UNKNOWN) {
         // return stored tool
         return probed_tool;
@@ -427,13 +429,13 @@ daptool_t DAP_FingerprintTool(const uint8_t *request, uint32_t request_len)
     if (request_len >= 2  &&  sample_no == 0) {
         ++sample_no;
 
-        if (request[0] == ID_DAP_Info  &&  request[1] == DAP_ID_PACKET_COUNT) {        // TODO hmmm... this does not work
+        if (request[0] == ID_DAP_Info  &&  request[1] == DAP_ID_PACKET_COUNT) {
             probed_tool = E_DAPTOOL_PYOCD;
         }
         else if (request[0] == ID_DAP_Info  &&  request[1] == DAP_ID_CAPABILITIES) {
             probed_tool = E_DAPTOOL_OPENOCD;
         }
-        else if (request[0] == ID_DAP_Info  &&  request[1] == DAP_ID_PACKET_SIZE) {    // TODO hmmm... this does not work
+        else if (request[0] == ID_DAP_Info  &&  request[1] == DAP_ID_PACKET_SIZE) {
             probed_tool = E_DAPTOOL_PROBERS;
         }
     }

--- a/src/cmsis-dap/dap_util.h
+++ b/src/cmsis-dap/dap_util.h
@@ -34,7 +34,6 @@ typedef enum {
     E_DAPTOOL_OPENOCD,
     E_DAPTOOL_PYOCD,
     E_DAPTOOL_PROBERS,
-    E_DAPTOOL_USER
 } daptool_t;
 
 

--- a/src/daplink-pico/detect_target.c
+++ b/src/daplink-pico/detect_target.c
@@ -416,6 +416,7 @@ void pico_prerun_board_config(void)
         probe_set_swclk_freq_khz(f_khz, true);
     }
 
+    target_set_state(HALT);
     target_set_state(RESET_RUN);
 }   // pico_prerun_board_config
 

--- a/src/daplink-pico/family/raspberry/rp2040/target_reset_rp2040.c
+++ b/src/daplink-pico/family/raspberry/rp2040/target_reset_rp2040.c
@@ -521,13 +521,6 @@ static void rp2040_swd_set_target_reset(uint8_t asserted)
 
 
 
-static bool delay_100ms(void)
-{
-    osDelay(100);
-    return true;
-}
-
-
 static uint8_t rp2040_target_set_state(target_state_t state)
 /**
  * Set state of the RP2040.
@@ -557,14 +550,14 @@ static uint8_t rp2040_target_set_state(target_state_t state)
         case RESET_PROGRAM:
             // Reset target and setup for flash programming
             // pre: -
-            r = rp2040_swd_set_target_state(1, HALT)  &&  delay_100ms()  &&  rp2040_swd_set_target_state(0, RESET_PROGRAM);
+            r = rp2040_swd_set_target_state(1, HALT)  &&  rp2040_swd_set_target_state(0, RESET_PROGRAM);
             // post: core1 in HALT, core0 ready for programming
             break;
 
         case RESET_RUN:
             // Reset target and run normally
             // pre: -
-            r = rp2040_swd_set_target_state(1, HALT)  &&  delay_100ms()  &&  rp2040_swd_set_target_state(0, RESET_RUN);
+            r = rp2040_swd_set_target_state(1, RESET_RUN)  &&  rp2040_swd_set_target_state(0, RESET_RUN);
             swd_off();
             // post: both cores are running
             break;
@@ -583,6 +576,7 @@ static uint8_t rp2040_target_set_state(target_state_t state)
             r = rp2040_swd_set_target_state(1, DEBUG)  &&  rp2040_swd_set_target_state(0, DEBUG);
             // post: core0 in DEBUG
             break;
+#endif
 
         case HALT:
             // Halt the target without resetting it
@@ -591,6 +585,7 @@ static uint8_t rp2040_target_set_state(target_state_t state)
             // post: both cores in HALT
             break;
 
+#if 0
         case RUN:
             // Resume the target without resetting it
             // pre: -
@@ -613,7 +608,7 @@ static uint8_t rp2040_target_set_state(target_state_t state)
 #endif
 
         case ATTACH:
-            r = rp2040_swd_set_target_state(1, ATTACH)  &&  delay_100ms()  &&  rp2040_swd_set_target_state(0, ATTACH);
+            r = rp2040_swd_set_target_state(1, ATTACH)  &&  rp2040_swd_set_target_state(0, ATTACH);
             break;
 
         default:

--- a/src/daplink-pico/family/raspberry/rp2350/target_reset_rp2350.c
+++ b/src/daplink-pico/family/raspberry/rp2350/target_reset_rp2350.c
@@ -59,6 +59,8 @@
     #define MY_ACCESSCTRL_WRITE_PASSWORD  0xacce0000u
 #endif
 
+#define SWJ_SEQ(LEN, ...) do { static const uint8_t data[] = __VA_ARGS__;   SWJ_Sequence(LEN, data); } while (0)
+
 extern target_family_descriptor_t g_raspberry_rp2350_family;
 static const uint32_t soft_reset = SYSRESETREQ;
 
@@ -85,21 +87,14 @@ static void swd_from_dormant(void)
  * Taken from RP2350 datasheet, "3.5.1 Connecting to the SW-DP"
  */
 {
-    const uint8_t ones_seq[]            = {0xff};
-    const uint8_t selection_alert_seq[] = {0x92, 0xf3, 0x09, 0x62, 0x95, 0x2d, 0x85, 0x86, 0xe9, 0xaf, 0xdd, 0xe3, 0xa2, 0x0e, 0xbc, 0x19};
-    const uint8_t zero_seq[]            = {0x00};
-    const uint8_t act_seq[]             = {0x1a};
-    const uint8_t reset_seq[]           = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x03};
+    printf("---swd_from_dormant()\n");
+
+    SWJ_SEQ(  8, {0xff});
+    SWJ_SEQ(128, {0x92, 0xf3, 0x09, 0x62, 0x95, 0x2d, 0x85, 0x86, 0xe9, 0xaf, 0xdd, 0xe3, 0xa2, 0x0e, 0xbc, 0x19});
+    SWJ_SEQ( 12, {0xa0, 0x01});
+    SWJ_SEQ( 54, {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x07});
+
     uint32_t rv;
-
-//    printf("---swd_from_dormant()\n");
-
-    SWJ_Sequence(  8, ones_seq);
-    SWJ_Sequence(128, selection_alert_seq);
-    SWJ_Sequence(  4, zero_seq);
-    SWJ_Sequence(  8, act_seq);
-    SWJ_Sequence( 52, reset_seq);
-
     swd_read_dp(DP_IDCODE, &rv);
 //    printf("---  id(%u)=0x%08lx\n", core, rv);   // 0x4c013477 is the RP2350
 }   // swd_from_dormant
@@ -283,10 +278,10 @@ static void rp2350_init_arm_core0(void)
     (void)swd_read_word(DCB_DSCSR, &dscsr);
     picoprobe_debug("DSCSR:  %08lx\n", dscsr);
     if ( !(dscsr & DSCSR_CDS)) {
-        picoprobe_info("Setting Current Domain Secure in DSCSR\n");
+//        picoprobe_info("Setting Current Domain Secure in DSCSR\n");
         (void)swd_write_word(DCB_DSCSR, (dscsr & ~DSCSR_CDSKEY) | DSCSR_CDS);
         (void)swd_read_word(DCB_DSCSR, &dscsr);
-        picoprobe_info("DSCSR*: %08x\n", (unsigned int)dscsr);
+//        picoprobe_info("DSCSR*: %08x\n", (unsigned int)dscsr);
     }
 }   // rp2350_init_arm_core0
 #endif
@@ -390,8 +385,7 @@ static bool rp2350_swd_init_debug(uint8_t core)
  * \return true -> ok
  *
  * \note
- *    - the current (hardware) reset operation does a reset of both cores
- *    -
+ *    Not all cases are filled because they are actually never used.  So do not waste time there.
  */
 static bool rp2350_swd_set_target_state(uint8_t core, target_state_t state)
 {
@@ -406,19 +400,15 @@ static bool rp2350_swd_set_target_state(uint8_t core, target_state_t state)
     }
 
     switch (state) {
-        case RESET_HOLD:
-            swd_set_target_reset(1);
-            break;
-
         case RESET_RUN:
+            if (!rp2350_swd_init_debug(core)) {
+                return false;
+            }
+
             swd_set_target_reset(1);
             osDelay(2);
             swd_set_target_reset(0);
             osDelay(2);
-
-            if (!rp2350_swd_init_debug(core)) {
-                return false;
-            }
 
             // reset C_HALT (required for RP2350)
             if (!swd_write_word(DBG_HCSR, DBGKEY)) {
@@ -510,33 +500,6 @@ static bool rp2350_swd_set_target_state(uint8_t core, target_state_t state)
             }
             break;
 
-        case NO_DEBUG:
-            if (!swd_write_word(DBG_HCSR, DBGKEY)) {
-                return false;
-            }
-            break;
-
-        case DEBUG:
-            if (!swd_clear_errors()) {
-                return false;
-            }
-
-            // Ensure CTRL/STAT register selected in DPBANKSEL
-            if (!swd_write_dp(DP_SELECT, 0)) {
-                return false;
-            }
-
-            // Power up
-            if (!swd_write_dp(DP_CTRL_STAT, CSYSPWRUPREQ | CDBGPWRUPREQ)) {
-                return false;
-            }
-
-            // Enable debug
-            if (!swd_write_word(DBG_HCSR, DBGKEY | C_DEBUGEN)) {
-                return false;
-            }
-            break;
-
         case HALT:
             if (!rp2350_swd_init_debug(core)) {
                 return false;
@@ -555,16 +518,6 @@ static bool rp2350_swd_set_target_state(uint8_t core, target_state_t state)
             } while ((val & S_HALT) == 0);
             break;
 
-        case RUN:
-            if (!swd_write_word(DBG_HCSR, DBGKEY)) {
-                return false;
-            }
-            break;
-
-        case POST_FLASH_RESET:
-            // This state should be handled in target_reset.c, nothing needs to be done here.
-            break;
-
         case ATTACH:
             // attach without doing anything else
             if (!rp2350_swd_init_debug(core)) {
@@ -573,7 +526,8 @@ static bool rp2350_swd_set_target_state(uint8_t core, target_state_t state)
             break;
 
         default:
-            return false;
+            panic("rp2350_swd_set_target_state() called with ill parameter %d,%d\n", (int)core, (int)state);
+            break;
     }
 
     return true;
@@ -583,7 +537,11 @@ static bool rp2350_swd_set_target_state(uint8_t core, target_state_t state)
 /*************************************************************************************************/
 
 
+#if 0
 static void rp2350_swd_set_target_reset(uint8_t asserted)
+/**
+ * Hardware signal is not guaranteed to exist
+ */
 {
     extern void probe_reset_pin_set(uint32_t);
 
@@ -591,6 +549,7 @@ static void rp2350_swd_set_target_reset(uint8_t asserted)
 //    printf("----- rp2350_swd_set_target_reset(%d)\n", asserted);
     probe_reset_pin_set(asserted ? 0 : 1);
 }   // rp2350_swd_set_target_reset
+#endif
 
 
 
@@ -599,27 +558,20 @@ static void rp2350_swd_set_target_reset(uint8_t asserted)
  * Currently core1 is held most of the time in HALT, so that it does not disturb operation.
  *
  * \note
- *    Take care, that core0 is the selected core at end of function
+ *    - take care, that core0 is the selected core at end of function
+ *    - not all cases are filled because they are actually never used.  So do not waste time there.
  */
 static uint8_t rp2350_target_set_state(target_state_t state)
 {
     uint8_t r = false;
 
-//    printf("---------------------------------------------- rp2350_target_set_state(%d)\n", state);
+    printf("---------------------------------------------- rp2350_target_set_state(%d)\n", state);
 
     switch (state) {
-        case RESET_HOLD:
-            // Hold target in reset
-            // pre: -
-            r = rp2350_swd_set_target_state(0, RESET_HOLD);
-            // post: both cores are in HW reset
-            break;
-
         case RESET_PROGRAM:
             // Reset target and setup for flash programming
             // pre: -
-            rp2350_swd_set_target_state(1, HALT);
-            r = rp2350_swd_set_target_state(0, RESET_PROGRAM);
+            r = rp2350_swd_set_target_state(1, HALT)  &&  rp2350_swd_set_target_state(0, RESET_PROGRAM);
             // post: core1 in HALT, core0 ready for programming
             break;
 
@@ -631,20 +583,6 @@ static uint8_t rp2350_target_set_state(target_state_t state)
             // post: both cores are running
             break;
 
-        case NO_DEBUG:
-            // Disable debug on running target
-            // pre: !swd_off()  &&  core0 selected
-            r = rp2350_swd_set_target_state(0, NO_DEBUG);
-            // post: core0 in NO_DEBUG
-            break;
-
-        case DEBUG:
-            // Enable debug on running target
-            // pre: !swd_off()  &&  core0 selected
-            r = rp2350_swd_set_target_state(0, DEBUG);
-            // post: core0 in DEBUG
-            break;
-
         case HALT:
             // Halt the target without resetting it
             // pre: -
@@ -652,32 +590,12 @@ static uint8_t rp2350_target_set_state(target_state_t state)
             // post: both cores in HALT
             break;
 
-        case RUN:
-            // Resume the target without resetting it
-            // pre: -
-            r = rp2350_swd_set_target_state(1, RUN)  &&  rp2350_swd_set_target_state(0, RUN);
-            swd_off();
-            // post: both cores are running
-            break;
-
-        case POST_FLASH_RESET:
-            // Reset target after flash programming
-            break;
-
-        case POWER_ON:
-            // Poweron the target
-            break;
-
-        case SHUTDOWN:
-            // Poweroff the target
-            break;
-
         case ATTACH:
             r = rp2350_swd_set_target_state(1, ATTACH)  &&  rp2350_swd_set_target_state(0, ATTACH);
             break;
 
         default:
-            r = false;
+            panic("rp2350_target_set_state() called with ill parameter %d\n", (int)state);
             break;
     }
 
@@ -689,7 +607,13 @@ static uint8_t rp2350_target_set_state(target_state_t state)
 
 target_family_descriptor_t g_raspberry_rp2350_family = {
     .family_id                = TARGET_RP2350_FAMILY_ID,
+#if 0
     .swd_set_target_reset     = &rp2350_swd_set_target_reset,
+#else
+    .default_reset_type       = kSoftwareReset,
+    .soft_reset_type          = SYSRESETREQ,
+    .swd_set_target_reset     = NULL,
+#endif
     .target_set_state         = &rp2350_target_set_state,
     .apsel = 0x2d00
 };

--- a/src/daplink-pico/family/raspberry/rp2350/target_reset_rp2350.c
+++ b/src/daplink-pico/family/raspberry/rp2350/target_reset_rp2350.c
@@ -95,7 +95,7 @@ static void swd_from_dormant(void)
     ok = swd_read_dp(DP_IDCODE, &rv);
 //    printf("---1  id(%d)=0x%08x %d\n", (int)core, (unsigned)rv, ok);   // 0x4c013477 is the RP2350
 
-    if ( !ok  ||  (rv & 0x0ff00ffe) != 0x0c000476) {
+    if ( !ok  ||  (rv & 0x0ff00ffe) != 0x0c000476) {      // TODO replace magic constants
 //        printf("---swd_from_dormant() - rp2350 - execute\n");
         SWJ_SEQ(  8, {0xff});
         SWJ_SEQ(128, {0x92, 0xf3, 0x09, 0x62, 0x95, 0x2d, 0x85, 0x86, 0xe9, 0xaf, 0xdd, 0xe3, 0xa2, 0x0e, 0xbc, 0x19});
@@ -125,7 +125,7 @@ static bool dp_core_select(uint8_t _core)
 
     g_raspberry_rp2350_family.apsel = 0x2d00;       // TODO where from is this xd00 ?  taken from openocd
     if (_core == 1) {
-        g_raspberry_rp2350_family.apsel = 0x4d00;
+        g_raspberry_rp2350_family.apsel = 0x4d00;       // TODO replace magic constants
     }
 
 #if 0

--- a/src/get_config.h
+++ b/src/get_config.h
@@ -32,16 +32,24 @@
 #define _xxCoNfSTR(S)  #S
 #define xxCoNfSTR(S)   _xxCoNfSTR(S)
 
+#if OPT_CMSIS_DAPV1  ||  OPT_CMSIS_DAPV2
+    #define __OPT_CMSIS_DAP           " [CMSIS:"
+    #define __OPT_CMSIS_DAP_END       "]"
+#else
+    #define __OPT_CMSIS_DAP
+    #define __OPT_CMSIS_DAP_END
+#endif
 #if OPT_CMSIS_DAPV1
-    #define __OPT_CMSIS_DAPV1         " [CMSIS: DAPv1]"
+    #define __OPT_CMSIS_DAPV1     " DAPv1"
 #else
     #define __OPT_CMSIS_DAPV1
 #endif
 #if OPT_CMSIS_DAPV2
-    #define __OPT_CMSIS_DAPV2         " [CMSIS: DAPv2]"
+    #define __OPT_CMSIS_DAPV2     " DAPv2"
 #else
     #define __OPT_CMSIS_DAPV2
 #endif
+
 #if OPT_MSC
     #define __OPT_MSC                 " [MSC: DAPLink]"
 #else
@@ -75,6 +83,7 @@
 #else
     #define __OPT_PROBE_DEBUG_OUT
 #endif
+
 #if OPT_NET
     #define __OPT_NET_IP              " [Net-"
     #if OPT_NET_PROTO_ECM
@@ -112,7 +121,8 @@
 /**
  * CONFIG_FEATURES
  */
-#define CONFIG_FEATURES()  __OPT_CMSIS_DAPV1 __OPT_CMSIS_DAPV2 __OPT_MSC __OPT_TARGET_UART __OPT_SIGROK           \
+#define CONFIG_FEATURES()  __OPT_CMSIS_DAP __OPT_CMSIS_DAPV1 __OPT_CMSIS_DAPV2 __OPT_CMSIS_DAP_END                \
+                           __OPT_MSC __OPT_TARGET_UART __OPT_SIGROK                                               \
                            __OPT_PROBE_DEBUG_OUT __OPT_CDC_SYSVIEW                                                \
                            __OPT_NET_CONF __OPT_NET_SYSVIEW_SERVER __OPT_NET_ECHO_SERVER __OPT_NET_IPERF_SERVER __OPT_NET_CONF_END
 

--- a/src/msc/msc_utils.c
+++ b/src/msc/msc_utils.c
@@ -37,6 +37,7 @@
 #include "msc_utils.h"
 #include "sw_lock.h"
 #include "led.h"
+#include "rtt_io.h"
 
 #include "FreeRTOS.h"
 #include "message_buffer.h"
@@ -106,8 +107,9 @@ static void target_disconnect(TimerHandle_t xTimer)
                 else {
                     flash_manager_uninit();
                 }
-                target_set_state(RESET_PROGRAM);
+                target_set_state(HALT);
                 target_set_state(RESET_RUN);
+                rtt_console_redetect();
             }
             is_connected = false;
         }
@@ -142,7 +144,7 @@ bool msc_target_connect(bool write_mode)
             picoprobe_info("=================================== MSC connect target\n");
             led_state(LS_MSC_CONNECTED);
 
-            ok = target_set_state(ATTACH);
+            ok = target_set_state(RESET_PROGRAM);
             must_initialize = ok;
             is_connected = true;                   // disconnect must be issued!
             had_write = false;

--- a/src/msc/msc_utils.c
+++ b/src/msc/msc_utils.c
@@ -37,7 +37,6 @@
 #include "msc_utils.h"
 #include "sw_lock.h"
 #include "led.h"
-#include "rtt_io.h"
 
 #include "FreeRTOS.h"
 #include "message_buffer.h"
@@ -99,8 +98,7 @@ static void target_disconnect(TimerHandle_t xTimer)
             picoprobe_info("=================================== MSC disconnect target: %d bytes transferred, %d bytes/s\n",
                            (int)transferred_bytes, (int)t_bps);
             led_state(LS_MSC_DISCONNECTED);
-            if (had_write)
-            {
+            if (had_write) {
                 if (USE_RP2040()) {
                 }
                 else if (USE_RP2350()) {

--- a/src/msc/msc_utils.c
+++ b/src/msc/msc_utils.c
@@ -99,7 +99,8 @@ static void target_disconnect(TimerHandle_t xTimer)
             picoprobe_info("=================================== MSC disconnect target: %d bytes transferred, %d bytes/s\n",
                            (int)transferred_bytes, (int)t_bps);
             led_state(LS_MSC_DISCONNECTED);
-            if (had_write) {
+            //if (had_write)                 // TODO not sure here
+            {
                 if (USE_RP2040()) {
                 }
                 else if (USE_RP2350()) {
@@ -107,7 +108,7 @@ static void target_disconnect(TimerHandle_t xTimer)
                 else {
                     flash_manager_uninit();
                 }
-                target_set_state(HALT);
+                target_set_state(RESET_PROGRAM);
                 target_set_state(RESET_RUN);
                 rtt_console_redetect();
             }

--- a/src/msc/msc_utils.c
+++ b/src/msc/msc_utils.c
@@ -99,7 +99,7 @@ static void target_disconnect(TimerHandle_t xTimer)
             picoprobe_info("=================================== MSC disconnect target: %d bytes transferred, %d bytes/s\n",
                            (int)transferred_bytes, (int)t_bps);
             led_state(LS_MSC_DISCONNECTED);
-            //if (had_write)                 // TODO not sure here
+            if (had_write)
             {
                 if (USE_RP2040()) {
                 }
@@ -110,7 +110,6 @@ static void target_disconnect(TimerHandle_t xTimer)
                 }
                 target_set_state(RESET_PROGRAM);
                 target_set_state(RESET_RUN);
-                rtt_console_redetect();
             }
             is_connected = false;
         }

--- a/src/rtt_io.c
+++ b/src/rtt_io.c
@@ -880,7 +880,7 @@ void rtt_sysview_send_byte(uint8_t ch)
 static void rtt_cb_console_redetect(TimerHandle_t xTimer)
 {
     // TODO implement
-    printf("yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\n");
+//    printf("yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\n");
 //    rtt_cb_active = 0;
 //    rtt_cb_redetect = true;
 }   // rtt_cb_console_redetect

--- a/src/rtt_io.c
+++ b/src/rtt_io.c
@@ -94,14 +94,12 @@ static EXT_SEGGER_RTT_CB_HEADER rtt_cb_header = {0};
 static bool                     rtt_console_running = false;
 static bool                     ok_console_from_target = false;
 static bool                     ok_console_to_target = false;
-static volatile bool            rtt_cb_redetect = false;
 
 static TaskHandle_t             task_rtt_console = NULL;
 static TaskHandle_t             task_rtt_from_target_thread = NULL;
 static StreamBufferHandle_t     stream_rtt_console_to_target;                  // small stream for host->probe->target console communication
 static EventGroupHandle_t       events;
 static TimerHandle_t            timer_rtt_dap_interleave;                      // minimum time do_rtt_io() should be active if DAP connected
-static TimerHandle_t            timer_rtt_redetect;
 
 #if INCLUDE_SYSVIEW
     #define RTT_CHANNEL_SYSVIEW 1
@@ -517,8 +515,7 @@ static void do_rtt_io(uint32_t rtt_cb)
     rtt_console_running = true;
     probe_rtt_cb = true;
     ok = true;
-    rtt_cb_redetect = false;
-    while (ok  &&  !rtt_cb_redetect) { //  &&  !sw_unlock_requested()) {
+    while (ok) { //  &&  !sw_unlock_requested()) {
         if (ok  &&  probe_rtt_cb) {
             //
             // check RTT control block and also all RTT channels
@@ -877,25 +874,6 @@ void rtt_sysview_send_byte(uint8_t ch)
 
 
 
-static void rtt_cb_console_redetect(TimerHandle_t xTimer)
-{
-    // TODO implement
-//    printf("yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\n");
-//    rtt_cb_active = 0;
-//    rtt_cb_redetect = true;
-}   // rtt_cb_console_redetect
-
-
-
-void rtt_console_redetect(void)
-{
-    xTimerReset(timer_rtt_redetect, 100);
-//    rtt_cb_active = 0;
-//    rtt_cb_redetect = true;
-}   // rtt_console_redetect
-
-
-
 void rtt_console_init(uint32_t task_prio)
 {
     picoprobe_debug("rtt_console_init()\n");
@@ -915,7 +893,6 @@ void rtt_console_init(uint32_t task_prio)
 #endif
 
     timer_rtt_dap_interleave = xTimerCreate("RTT/DAP interleave timeout", pdMS_TO_TICKS(8),   pdFALSE, NULL, rtt_cb_verify_timeout);
-    timer_rtt_redetect       = xTimerCreate("RTT/redetect",               pdMS_TO_TICKS(550), pdFALSE, NULL, rtt_cb_console_redetect);
 
     xTaskCreate(rtt_io_thread, "RTT-IO", configMINIMAL_STACK_SIZE, NULL, task_prio, &task_rtt_console);
     if (task_rtt_console == NULL)

--- a/src/rtt_io.h
+++ b/src/rtt_io.h
@@ -39,6 +39,7 @@
 void rtt_console_init(uint32_t task_prio);
 void rtt_console_send_byte(uint8_t ch);
 bool rtt_console_cb_exists(void);
+void rtt_console_redetect(void);
 
 #if OPT_NET_SYSVIEW_SERVER  ||  OPT_CDC_SYSVIEW
     void rtt_sysview_send_byte(uint8_t ch);

--- a/src/rtt_io.h
+++ b/src/rtt_io.h
@@ -39,7 +39,6 @@
 void rtt_console_init(uint32_t task_prio);
 void rtt_console_send_byte(uint8_t ch);
 bool rtt_console_cb_exists(void);
-void rtt_console_redetect(void);
 
 #if OPT_NET_SYSVIEW_SERVER  ||  OPT_CDC_SYSVIEW
     void rtt_sysview_send_byte(uint8_t ch);


### PR DESCRIPTION
* DAP server reworked, taken from original debugprobe
  * now all tools can use 16 packets with 64 bytes length, have to investigate larger buffers
  * packet cnt/size no longer user settable
* rp2040 wake up sequence can now handle stale DP (at least I'm hoping so)
* rp2350 wake up reworked
* try to start target (more) reliable
* lot of minor stuff