### PR TITLE
rp2040: use software reset in RESET_RUN to avoid GPIO6 interference

### DIFF
--- a/src/daplink-pico/family/raspberry/rp2040/target_reset_rp2040.c
+++ b/src/daplink-pico/family/raspberry/rp2040/target_reset_rp2040.c
@@ -320,14 +320,22 @@ static bool rp2040_swd_set_target_state(uint8_t core, target_state_t state)
 
     switch (state) {
         case RESET_RUN:
-            // TODO what should be done here actually?
             if ( !rp2040_swd_init_debug(core)) {
                 return false;
             }
 
-            swd_set_target_reset(1);
-            osDelay(2);
-            swd_set_target_reset(0);
+            // Use software reset (SYSRESETREQ) instead of hardware reset.
+            // The RP2040 family sets swd_set_target_reset=NULL, so calling
+            // swd_set_target_reset() falls back to PIN_nRESET_OUT which drives the
+            // RST/RUN pin (GPIO6) LOW, holding the DUT in reset indefinitely and
+            // blocking external debugger connections.  SYSRESETREQ is consistent with
+            // default_reset_type=kSoftwareReset in the RP2040 family descriptor.
+            {
+                uint32_t aircr;
+                if (swd_read_word(NVIC_AIRCR, &aircr)) {
+                    swd_write_word(NVIC_AIRCR, VECTKEY | (aircr & SCB_AIRCR_PRIGROUP_Msk) | soft_reset);
+                }
+            }
             osDelay(2);
 
             // Power down


### PR DESCRIPTION
# Pull Request: Fix Startup Reset Loop and SWD Interference for RP2040 Targets

## Problem Description
When using YAPicoprobe on hardware where the `RST` line is physically connected to the target (such as the [Pico Debug Stack](https://github.com/frohro/Pico_Debug_Stack)), external debuggers (PlatformIO, Cortex-Debug, etc.) often fail to connect.

The root cause is the background RTT polling task. When idle, `rtt_io_thread` periodically calls `pico_prerun_board_config()` -> `target_set_state(RESET_RUN)`. In the RP2040 family implementation, `RESET_RUN` was calling `swd_set_target_reset(1)`, which falls back to driving the hardware `nRESET` pin (GPIO6) LOW because the RP2040 family descriptor defines `swd_set_target_reset` as `NULL`.

This created a "reset loop" every ~100ms that constantly kicked the target out of its boot state and interfered with external SWD probes.

## Solution
Modified `rp2040_swd_set_target_state` to use a software reset (`SYSRESETREQ`) via the `NVIC_AIRCR` register instead of a hardware reset during the `RESET_RUN` sequence.

This allows the probe to successfully reset the target for RTT scanning without asserting the physical `RST` pin, ensuring compatibility with external debuggers while maintaining full RTT functionality.

## Changes
- Updated `src/daplink-pico/family/raspberry/rp2040/target_reset_rp2040.c`
- Replaced `swd_set_target_reset(1/0)` with `SYSRESETREQ` logic in the `RESET_RUN` case.
- Added documentation comments explaining why the hardware reset fallback was problematic.

## Testing Performed
- **Hardware:** RP2354B Probe (U2) connected to RP2040 Target (U1) via the Pico Debug Stack PCB.
- **Verification:** 
    - Confirmed SWD connects reliably from host PC without disconnecting the `RST` line.
    - Verified firmware uploading and debugging works as expected.
    - Verified RTT console still functions correctly after the software reset.
    - Verified the fix compiles cleanly for `PICO_BOARD=pico2`.
### Hardware and Software Used for Testing
I used the Pico-Debug-Stack (https://github.com/frohro/Pico_Debug_Stack) with a YD-RP2040 as the target.  I tested this in PlatformIO and with Cortex-Debug.

## Impact
This change strictly improves interoperability with other debug tools and prevents unsolicited hardware resets on boards where the reset line is wired up. It is consistent with the RP2040 family's declared `default_reset_type = kSoftwareReset`.
