### PR TITLE
Fix CMSIS-DAPv1 compatibility with Windows hosts and Keil MDK

### DIFF
--- a/include/DAP_config.h
+++ b/include/DAP_config.h
@@ -166,7 +166,7 @@ __STATIC_INLINE uint8_t DAP_GetVendorString (char *str)
 */
 __STATIC_INLINE uint8_t DAP_GetProductString (char *str)
 {
-    strcpy(str, "YAPicoprobe");
+    strcpy(str, "YAPicoprobe CMSIS-DAP");
     return strlen(str) + 1;
 }
 

--- a/src/cmsis-dap/dap_server.c
+++ b/src/cmsis-dap/dap_server.c
@@ -27,6 +27,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 #include <pico/stdlib.h>
 
@@ -275,7 +276,25 @@
     static uint8_t TxDataBuffer[_DAP_PACKET_SIZE_HID];
 #endif
 
+static uint32_t dap_execute_command(const uint8_t *request, uint8_t *response, const char *product_str)
+/**
+ * Execute a DAP command and, for DAP_Info(Product ID) requests, overwrite the
+ * product string in the response.  This allows host tools to distinguish the
+ * CMSIS-DAPv1 and CMSIS-DAPv2 interfaces of the probe.
+ */
+{
+    uint32_t res = DAP_ExecuteCommand(request, response);
 
+    if (product_str != NULL  &&  request[0] == ID_DAP_Info  &&  request[1] == DAP_ID_PRODUCT) {
+        uint32_t len = (uint32_t)strlen(product_str) + 1;   // include trailing zero
+
+        response[0] = ID_DAP_Info;
+        response[1] = (uint8_t)len;
+        memcpy(response + 2, product_str, len);
+        res = (res & 0xffff0000) | (len + 2);
+    }
+    return res;
+}
 
 #if OPT_CMSIS_DAPV2  &&  !defined(NEW_DAP)
 
@@ -696,8 +715,8 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
         }
         picoprobe_info_out("\n");
 #else
-        uint32_t res = DAP_ExecuteCommand(RxDataBuffer, TxDataBuffer);
-	(void) res;
+        uint32_t res = dap_execute_command(RxDataBuffer, TxDataBuffer, "YAPicoprobe CMSIS-DAP v1");
+        (void) res;
 #endif
         tud_hid_report(0, TxDataBuffer, _DAP_PACKET_SIZE_HID);
     }
@@ -1035,7 +1054,7 @@ void dap_thread(void *ptr)
             // execute DAP request
             //
             HandleDapConnectDisconnect(RD_SLOT_PTR(requestQueue), RD_SLOT_LEN(requestQueue));
-            resp_len = DAP_ExecuteCommand(RD_SLOT_PTR(requestQueue), WR_SLOT_PTR(responseQueue)) & 0xffff;
+            resp_len = dap_execute_command(RD_SLOT_PTR(requestQueue), WR_SLOT_PTR(responseQueue), "YAPicoprobe CMSIS-DAP v2") & 0xffff;
 
             xSemaphoreTake(edpt_spoon, portMAX_DELAY);
 

--- a/src/cmsis-dap/dap_server.c
+++ b/src/cmsis-dap/dap_server.c
@@ -276,22 +276,45 @@
     static uint8_t TxDataBuffer[_DAP_PACKET_SIZE_HID];
 #endif
 
-static uint32_t dap_execute_command(const uint8_t *request, uint8_t *response, const char *product_str)
+
+
+static uint32_t dap_execute_command(const uint8_t *request, uint8_t *response, const char *product_str,
+                                    uint8_t packet_count, uint16_t packet_size)
 /**
- * Execute a DAP command and, for DAP_Info(Product ID) requests, overwrite the
- * product string in the response.  This allows host tools to distinguish the
- * CMSIS-DAPv1 and CMSIS-DAPv2 interfaces of the probe.
+ * Execute a DAP command and, for DAP_Info requests, overwrite selected values
+ * in the response:
+ * - Product ID: use product_str.  This allows host tools to distinguish the
+ *   CMSIS-DAPv1 and CMSIS-DAPv2 interfaces of the probe.
+ * - Packet Count/Size: use packet_count/packet_size if packet_count != 0.
+ *   Required for the v1 (HID) interface, because the global dap_packet_count/
+ *   dap_packet_size reflect the v2 values (16/64) which the single-buffered
+ *   HID path cannot actually handle.
  */
 {
     uint32_t res = DAP_ExecuteCommand(request, response);
 
-    if (product_str != NULL  &&  request[0] == ID_DAP_Info  &&  request[1] == DAP_ID_PRODUCT) {
-        uint32_t len = (uint32_t)strlen(product_str) + 1;   // include trailing zero
+    if (request[0] == ID_DAP_Info) {
+        if (product_str != NULL  &&  request[1] == DAP_ID_PRODUCT) {
+            uint32_t len = (uint32_t)strlen(product_str) + 1;   // include trailing zero
 
-        response[0] = ID_DAP_Info;
-        response[1] = (uint8_t)len;
-        memcpy(response + 2, product_str, len);
-        res = (res & 0xffff0000) | (len + 2);
+            response[0] = ID_DAP_Info;
+            response[1] = (uint8_t)len;
+            memcpy(response + 2, product_str, len);
+            res = (res & 0xffff0000) | (len + 2);
+        }
+        else if (packet_count != 0  &&  request[1] == DAP_ID_PACKET_COUNT) {
+            response[0] = ID_DAP_Info;
+            response[1] = 1;
+            response[2] = packet_count;
+            res = (res & 0xffff0000) | 3;
+        }
+        else if (packet_count != 0  &&  request[1] == DAP_ID_PACKET_SIZE) {
+            response[0] = ID_DAP_Info;
+            response[1] = 2;
+            response[2] = (uint8_t)packet_size;
+            response[3] = (uint8_t)(packet_size >> 8);
+            res = (res & 0xffff0000) | 4;
+        }
     }
     return res;
 }
@@ -715,7 +738,8 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
         }
         picoprobe_info_out("\n");
 #else
-        uint32_t res = dap_execute_command(RxDataBuffer, TxDataBuffer, "YAPicoprobe CMSIS-DAP v1");
+        uint32_t res = dap_execute_command(RxDataBuffer, TxDataBuffer, "YAPicoprobe CMSIS-DAP v1",
+                                           _DAP_PACKET_COUNT_HID, _DAP_PACKET_SIZE_HID);
         (void) res;
 #endif
         tud_hid_report(0, TxDataBuffer, _DAP_PACKET_SIZE_HID);
@@ -1054,7 +1078,7 @@ void dap_thread(void *ptr)
             // execute DAP request
             //
             HandleDapConnectDisconnect(RD_SLOT_PTR(requestQueue), RD_SLOT_LEN(requestQueue));
-            resp_len = dap_execute_command(RD_SLOT_PTR(requestQueue), WR_SLOT_PTR(responseQueue), "YAPicoprobe CMSIS-DAP v2") & 0xffff;
+            resp_len = dap_execute_command(RD_SLOT_PTR(requestQueue), WR_SLOT_PTR(responseQueue), "YAPicoprobe CMSIS-DAP v2", 0, 0) & 0xffff;
 
             xSemaphoreTake(edpt_spoon, portMAX_DELAY);
 

--- a/src/cmsis-dap/dap_server.c
+++ b/src/cmsis-dap/dap_server.c
@@ -697,8 +697,9 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
         picoprobe_info_out("\n");
 #else
         uint32_t res = DAP_ExecuteCommand(RxDataBuffer, TxDataBuffer);
+	(void) res;
 #endif
-        tud_hid_report(0, TxDataBuffer, res & 0xffff);
+        tud_hid_report(0, TxDataBuffer, _DAP_PACKET_SIZE_HID);
     }
 }   // tud_hid_set_report_cb
 #endif


### PR DESCRIPTION
## Summary
Four fixes that make the CMSIS-DAPv1 (HID) interface usable on Windows and with Keil MDK.
v2, pyocd and OpenOCD were mostly unaffected, which is why these went unnoticed.
- **Always send full-size (64 byte) HID reports** (0246e1a)
Responses were sent with their exact length, but Windows hidclass does not
deliver interrupt-IN reports shorter than the report descriptor size to
applications (Linux hidraw does).  Short responses (e.g. DAP_Info) never
reached the host and `pyocd list` hung on Windows.
- **Include "CMSIS-DAP" in the product string** (a833179)
The CMSIS-DAP spec requires the product string to contain "CMSIS-DAP"
(https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__ConfigUSB__gr.html).
Keil MDK checks this via `DAP_Info(Product ID)` and did not list the probe
at all with the plain "YAPicoprobe" string.
- **Report per-channel product strings** (f1594ae)
v1 and v2 returned identical `DAP_Info(Product ID)` responses, so both
interfaces showed up as the same name in Keil's adapter list.  Now
"YAPicoprobe CMSIS-DAP v1" / "... v2" (both still contain "CMSIS-DAP").
- **Report packet count/size actually supported by the v1 HID interface** (cf3e08e)
`DAP_Info(Packet Count/Size)` answered from the globals carrying the v2
values (16x64), which the single-buffered HID path cannot handle (one
command per report, one response in flight).  Keil MDK pipelines requests
based on the advertised count, responses were lost and flash download
aborted with "RDDI-DAP Error / Flash Download failed".  The v1 channel now
reports 1x64.
## Tested
- Windows 10/11: pyocd (v1 + v2) detect/connect/flash, no more hangs
- Keil MDK 5.24: detects DAPv1, flash download to HC32F460 works
- Newer Keil MDK: v1/v2 adapter entries clearly distinguished
- Target used for verification: HC32F460 (SWD, IDCODE read + flash download)